### PR TITLE
Added missing location for Collector Astorestes in Bastion

### DIFF
--- a/plugins/09_Shadowlands/zones/bastion.lua
+++ b/plugins/09_Shadowlands/zones/bastion.lua
@@ -147,7 +147,8 @@ map.nodes[66004367] = Rare({
             65844451, -- Mercia's Legacy: Chapter Seven
             66214333, -- Mercia's Legacy: Chapter Seven
             67394283, -- Mercia's Legacy: Chapter Seven
-            67604342 -- Mercia's Legacy: Chapter Seven
+            67604342, -- Mercia's Legacy: Chapter Seven
+            65304440 -- Mercia's Legacy: Chapter Seven
         })
     }
 }) -- Collector Astorestes


### PR DESCRIPTION
This location was listed on Wowhead but not in HandyNotes. Found the item there, so the location is valid