### PR TITLE
Bug fixes and new features for Legion

### DIFF
--- a/plugins/07_Legion/common.lua
+++ b/plugins/07_Legion/common.lua
@@ -12,6 +12,14 @@ ns.expansion = 7
 ----------------------------------- GROUPS ------------------------------------
 -------------------------------------------------------------------------------
 
+ns.groups.LEGION_WAR_SUPPLIES = Group('legion_war_supplies', 'chest_bk',
+    {defaults = ns.GROUP_HIDDEN75})
+ns.groups.EREDAR_WAR_SUPPLIES = Group('eredar_war_supplies', 'chest_bk',
+    {defaults = ns.GROUP_HIDDEN75})
+ns.groups.ANCIENT_EREDAR_CACHE = Group('ancient_eredar_cache', 'chest_bk',
+    {defaults = ns.GROUP_HIDDEN75})
+ns.groups.VOID_SEEPED_CACHE = Group('void_seeped_cache', 'chest_bk',
+    {defaults = ns.GROUP_HIDDEN75})
 ns.groups.BRINGING_HOME_THE_BEACON = Group('bringing_home_the_beacon', 133267,
     {defaults = ns.GROUP_HIDDEN})
 ns.groups.HIGHER_DIMENSIONAL_LEARNING = Group('higher_dimensional_learning',

--- a/plugins/07_Legion/localization/deDE.lua
+++ b/plugins/07_Legion/localization/deDE.lua
@@ -19,6 +19,12 @@ L['the_many_faced_devourer_checklist'] = '|cFFFFD700Checkliste (in der Tasche od
 
 L['orix_the_all_seer_note'] = 'Verkauft Sammlerstücke im Tausch gegen {item:153021}.'
 
+L['legion_war_supplies'] = nil
+L['legion_war_supplies_note'] = nil
+
+L['options_icons_legion_war_supplies'] = nil
+L['options_icons_legion_war_supplies_desc'] = nil
+
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
 -------------------------------------------------------------------------------
@@ -111,6 +117,16 @@ L['bohdi_sunwayver_note'] = 'Die Sonne kommt raus! Alle Haustiere nach draußen!
 L['kaara_the_pale_note'] = nil
 L['turek_the_lucid_note'] = nil
 
+L['ancient_eredar_cache'] = nil
+L['ancient_eredar_cache_note'] = nil
+L['void_seeped_cache'] = nil
+L['void_seeped_cache_note'] = nil
+
+L['options_icons_ancient_eredar_cache'] = nil
+L['options_icons_ancient_eredar_cache_desc'] = nil
+L['options_icons_void_seeped_cache'] = nil
+L['options_icons_void_seeped_cache_desc'] = nil
+
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
 -------------------------------------------------------------------------------
@@ -118,6 +134,16 @@ L['turek_the_lucid_note'] = nil
 L['odrogg_note'] = 'Ihr glaubt, Ihr könnt meinen Schnecken bezwingen?'
 L['grixis_tinypop_note'] = 'Das wird leicht!'
 L['bredda_tenderhide_note'] = 'Mögen die Tapfersten siegreich sein!'
+
+-------------------------------------------------------------------------------
+-------------------------------- KROKUUN --------------------------------------
+-------------------------------------------------------------------------------
+
+L['eredar_war_supplies'] = nil
+L['eredar_war_supplies_note'] = nil
+
+L['options_icons_eredar_war_supplies'] = nil
+L['options_icons_eredar_war_supplies_desc'] = nil
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/localization/enUS.lua
+++ b/plugins/07_Legion/localization/enUS.lua
@@ -22,6 +22,12 @@ L['the_many_faced_devourer_checklist'] = Gold('Item Checklist (in bags or bank):
 
 L['orix_the_all_seer_note'] = 'Sells collectibles in exchange for {item:153021}.'
 
+L['legion_war_supplies'] = 'Legion War Supplies'
+L['legion_war_supplies_note'] = 'There are 9 unique legion war supplies that can each appear at set locations.'
+
+L['options_icons_legion_war_supplies'] = 'Legion War Supplies'
+L['options_icons_legion_war_supplies_desc'] = 'Display possible locations for legion war supplies (daily chests).'
+
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
 -------------------------------------------------------------------------------
@@ -112,6 +118,16 @@ L['bohdi_sunwayver_note'] = 'Sun\'s out! Pets out!'
 L['kaara_the_pale_note'] = '{npc:126860} no longer drops {item:153190}'
 L['turek_the_lucid_note'] = 'In the |cFFFFFD00Oronaar Collapse|r'
 
+L['ancient_eredar_cache'] = 'Ancient Eredar Cache'
+L['ancient_eredar_cache_note'] = 'There are 6 unique ancient eredar caches that can each appear at set locations.'
+L['void_seeped_cache'] = 'Void-Seeped Cache'
+L['void_seeped_cache_note'] = 'There are 2 unique void-seeped caches that can each appear at set locations. |c00ff0000These do not contain transmogs.|r'
+
+L['options_icons_ancient_eredar_cache'] = 'Ancient Eredar Cache'
+L['options_icons_ancient_eredar_cache_desc'] = 'Display possible locations for ancient eredar caches (daily chests).'
+L['options_icons_void_seeped_cache'] = 'Void-Seeped Cache'
+L['options_icons_void_seeped_cache_desc'] = 'Display possible locations for void-seeped caches (daily chests).'
+
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
 -------------------------------------------------------------------------------
@@ -119,6 +135,16 @@ L['turek_the_lucid_note'] = 'In the |cFFFFFD00Oronaar Collapse|r'
 L['odrogg_note'] = 'You think you can best my snails?'
 L['grixis_tinypop_note'] = 'This\'ll be easy!'
 L['bredda_tenderhide_note'] = 'Let the bravest prove victorious!'
+
+-------------------------------------------------------------------------------
+-------------------------------- KROKUUN --------------------------------------
+-------------------------------------------------------------------------------
+
+L['eredar_war_supplies'] = 'Eredar War Supplies'
+L['eredar_war_supplies_note'] = 'There are 7 unique eredar war supplies that can each appear at set locations.'
+
+L['options_icons_eredar_war_supplies'] = 'Eredar War Supplies'
+L['options_icons_eredar_war_supplies_desc'] = 'Display possible locations for eredar war supplies (daily chests).'
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/localization/esES.lua
+++ b/plugins/07_Legion/localization/esES.lua
@@ -23,6 +23,12 @@ L['the_many_faced_devourer_checklist'] = Gold('Lista de chequeo de Objetos (en b
 
 L['orix_the_all_seer_note'] = 'Vende coleccionables a cambio de {item:153021}.'
 
+L['legion_war_supplies'] = nil
+L['legion_war_supplies_note'] = nil
+
+L['options_icons_legion_war_supplies'] = nil
+L['options_icons_legion_war_supplies_desc'] = nil
+
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
 -------------------------------------------------------------------------------
@@ -113,6 +119,16 @@ L['bohdi_sunwayver_note'] = '¡Ha salido el sol! ¡Mascotas fuera!'
 L['kaara_the_pale_note'] = '{npc:126860} ya no suelta el {item:153190}'
 L['turek_the_lucid_note'] = 'En el |cFFFFFD00Derrumbe de Oronaar|r'
 
+L['ancient_eredar_cache'] = nil
+L['ancient_eredar_cache_note'] = nil
+L['void_seeped_cache'] = nil
+L['void_seeped_cache_note'] = nil
+
+L['options_icons_ancient_eredar_cache'] = nil
+L['options_icons_ancient_eredar_cache_desc'] = nil
+L['options_icons_void_seeped_cache'] = nil
+L['options_icons_void_seeped_cache_desc'] = nil
+
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
 -------------------------------------------------------------------------------
@@ -120,6 +136,16 @@ L['turek_the_lucid_note'] = 'En el |cFFFFFD00Derrumbe de Oronaar|r'
 L['odrogg_note'] = '¿Crees que puedes superar a mis caracoles?'
 L['grixis_tinypop_note'] = '¡Esto va a ser fácil!'
 L['bredda_tenderhide_note'] = '¡Que los más valientes resulten victoriosos!'
+
+-------------------------------------------------------------------------------
+-------------------------------- KROKUUN --------------------------------------
+-------------------------------------------------------------------------------
+
+L['eredar_war_supplies'] = nil
+L['eredar_war_supplies_note'] = nil
+
+L['options_icons_eredar_war_supplies'] = nil
+L['options_icons_eredar_war_supplies_desc'] = nil
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/localization/esES.lua
+++ b/plugins/07_Legion/localization/esES.lua
@@ -23,11 +23,11 @@ L['the_many_faced_devourer_checklist'] = Gold('Lista de chequeo de Objetos (en b
 
 L['orix_the_all_seer_note'] = 'Vende coleccionables a cambio de {item:153021}.'
 
-L['legion_war_supplies'] = nil
-L['legion_war_supplies_note'] = nil
+L['legion_war_supplies'] = 'Suministros Bélicos de la Legión'
+L['legion_war_supplies_note'] = 'Hay 9 Suministros bélicos de la Legión únicos que pueden aparecer en sitios determinados.'
 
-L['options_icons_legion_war_supplies'] = nil
-L['options_icons_legion_war_supplies_desc'] = nil
+L['options_icons_legion_war_supplies'] = 'Suministros Bélicos de la Legión'
+L['options_icons_legion_war_supplies_desc'] = 'Muestra dónde pueden estar los Suministros bélicos de la Legión (cofres diarios).'
 
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
@@ -119,15 +119,15 @@ L['bohdi_sunwayver_note'] = '¡Ha salido el sol! ¡Mascotas fuera!'
 L['kaara_the_pale_note'] = '{npc:126860} ya no suelta el {item:153190}'
 L['turek_the_lucid_note'] = 'En el |cFFFFFD00Derrumbe de Oronaar|r'
 
-L['ancient_eredar_cache'] = nil
-L['ancient_eredar_cache_note'] = nil
-L['void_seeped_cache'] = nil
-L['void_seeped_cache_note'] = nil
+L['ancient_eredar_cache'] = 'Alijo Eredar Antiguo'
+L['ancient_eredar_cache_note'] = 'Hay 6 Alijo eredar antiguo únicos que pueden aparecer en sitios determinados.'
+L['void_seeped_cache'] = 'Alijo Calado de Vacío'
+L['void_seeped_cache_note'] = 'Hay 2 Alijo calado de Vacío únicos que pueden aparecer en sitios determinados. |c00ff0000Estos no contienen transfiguraciones.|r'
 
-L['options_icons_ancient_eredar_cache'] = nil
-L['options_icons_ancient_eredar_cache_desc'] = nil
-L['options_icons_void_seeped_cache'] = nil
-L['options_icons_void_seeped_cache_desc'] = nil
+L['options_icons_ancient_eredar_cache'] = 'Alijo Eredar Antiguo'
+L['options_icons_ancient_eredar_cache_desc'] = 'Muestra dónde pueden estar los Alijo eredar antiguo (cofres diarios).'
+L['options_icons_void_seeped_cache'] = 'Alijo Calado de Vacío'
+L['options_icons_void_seeped_cache_desc'] = 'Muestra dónde pueden estar los Alijo calado de Vacío (cofres diarios).'
 
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
@@ -141,11 +141,11 @@ L['bredda_tenderhide_note'] = '¡Que los más valientes resulten victoriosos!'
 -------------------------------- KROKUUN --------------------------------------
 -------------------------------------------------------------------------------
 
-L['eredar_war_supplies'] = nil
-L['eredar_war_supplies_note'] = nil
+L['eredar_war_supplies'] = 'Suministros Bélicos Eredar'
+L['eredar_war_supplies_note'] = 'Hay 7 Suministros bélicos eredar únicos que pueden aparecer en sitios determinados.'
 
-L['options_icons_eredar_war_supplies'] = nil
-L['options_icons_eredar_war_supplies_desc'] = nil
+L['options_icons_eredar_war_supplies'] = 'Suministros Bélicos Eredar'
+L['options_icons_eredar_war_supplies_desc'] = 'Muestra dónde pueden estar los Suministros bélicos eredar (cofres diarios).'
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/localization/frFR.lua
+++ b/plugins/07_Legion/localization/frFR.lua
@@ -23,6 +23,12 @@ L['the_many_faced_devourer_checklist'] = Gold('Check-list des objets (dans les s
 
 L['orix_the_all_seer_note'] = 'Vend des objets de collection en échange d\'{item:153021}.'
 
+L['legion_war_supplies'] = nil
+L['legion_war_supplies_note'] = nil
+
+L['options_icons_legion_war_supplies'] = nil
+L['options_icons_legion_war_supplies_desc'] = nil
+
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
 -------------------------------------------------------------------------------
@@ -113,6 +119,16 @@ L['bohdi_sunwayver_note'] = 'Le soleil est de sortie, les familiers aussi !'
 L['kaara_the_pale_note'] = '{npc:126860} ne lâche plus {item:153190}'
 L['turek_the_lucid_note'] = 'Dans l’|cFFFFFD00Effondrement d’Oronaar|r'
 
+L['ancient_eredar_cache'] = nil
+L['ancient_eredar_cache_note'] = nil
+L['void_seeped_cache'] = nil
+L['void_seeped_cache_note'] = nil
+
+L['options_icons_ancient_eredar_cache'] = nil
+L['options_icons_ancient_eredar_cache_desc'] = nil
+L['options_icons_void_seeped_cache'] = nil
+L['options_icons_void_seeped_cache_desc'] = nil
+
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
 -------------------------------------------------------------------------------
@@ -120,6 +136,16 @@ L['turek_the_lucid_note'] = 'Dans l’|cFFFFFD00Effondrement d’Oronaar|r'
 L['odrogg_note'] = 'Vous pensez que vous pouvez battre mes escargots ?'
 L['grixis_tinypop_note'] = 'Ce sera facile !'
 L['bredda_tenderhide_note'] = 'Que le plus courageux soit victorieux !'
+
+-------------------------------------------------------------------------------
+-------------------------------- KROKUUN --------------------------------------
+-------------------------------------------------------------------------------
+
+L['eredar_war_supplies'] = nil
+L['eredar_war_supplies_note'] = nil
+
+L['options_icons_eredar_war_supplies'] = nil
+L['options_icons_eredar_war_supplies_desc'] = nil
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/localization/zhCN.lua
+++ b/plugins/07_Legion/localization/zhCN.lua
@@ -22,6 +22,12 @@ L['the_many_faced_devourer_checklist'] = Gold('物品检查表（背包或银行
 
 L['orix_the_all_seer_note'] = '出售收藏品换取 {item:153021}。'
 
+L['legion_war_supplies'] = nil
+L['legion_war_supplies_note'] = nil
+
+L['options_icons_legion_war_supplies'] = nil
+L['options_icons_legion_war_supplies_desc'] = nil
+
 -------------------------------------------------------------------------------
 ------------------------------------ ARGUS ------------------------------------
 -------------------------------------------------------------------------------
@@ -115,6 +121,16 @@ L['bohdi_sunwayver_note'] = '太阳出来啦！宠物们，出击吧！'
 L['kaara_the_pale_note'] = '{npc:126860} 不再掉落 {item:153190}'
 L['turek_the_lucid_note'] = '在 |cFFFFFD00奥罗纳尔陷坑|r 内'
 
+L['ancient_eredar_cache'] = nil
+L['ancient_eredar_cache_note'] = nil
+L['void_seeped_cache'] = nil
+L['void_seeped_cache_note'] = nil
+
+L['options_icons_ancient_eredar_cache'] = nil
+L['options_icons_ancient_eredar_cache_desc'] = nil
+L['options_icons_void_seeped_cache'] = nil
+L['options_icons_void_seeped_cache_desc'] = nil
+
 -------------------------------------------------------------------------------
 -------------------------------- HIGHMOUNTAIN ---------------------------------
 -------------------------------------------------------------------------------
@@ -122,6 +138,16 @@ L['turek_the_lucid_note'] = '在 |cFFFFFD00奥罗纳尔陷坑|r 内'
 L['odrogg_note'] = '你以为你能击败我的蜗牛？'
 L['grixis_tinypop_note'] = '这完全是小菜一碟！'
 L['bredda_tenderhide_note'] = '狭路相逢勇者胜！'
+
+-------------------------------------------------------------------------------
+-------------------------------- KROKUUN --------------------------------------
+-------------------------------------------------------------------------------
+
+L['eredar_war_supplies'] = nil
+L['eredar_war_supplies_note'] = nil
+
+L['options_icons_eredar_war_supplies'] = nil
+L['options_icons_eredar_war_supplies_desc'] = nil
 
 -------------------------------------------------------------------------------
 --------------------------------- STORMHEIM -----------------------------------

--- a/plugins/07_Legion/zones/antoran_wastes.lua
+++ b/plugins/07_Legion/zones/antoran_wastes.lua
@@ -365,6 +365,7 @@ local LWSupplies = Class('LWSupplies', Treasure, {
     group = ns.groups.LEGION_WAR_SUPPLIES,
     label = L['legion_war_supplies'],
     note = L['legion_war_supplies_note'],
+    requires = ns.requirement.Quest(47473), -- Sizing Up The Opposition
     rewards = {
         Transmog({item = 153339, slot = L['plate']}), -- Triumvirate High Guard's Casque
         Transmog({item = 153342, slot = L['plate']}), -- Triumvirate High Guard's Pauldrons

--- a/plugins/07_Legion/zones/antoran_wastes.lua
+++ b/plugins/07_Legion/zones/antoran_wastes.lua
@@ -358,6 +358,109 @@ map.nodes[75705260] = Treasure({
 }) -- Timeworn Fel Chest
 
 -------------------------------------------------------------------------------
+------------------------------ DAILY CHESTS -----------------------------------
+-------------------------------------------------------------------------------
+
+local LWSupplies = Class('LWSupplies', Treasure, {
+    group = ns.groups.LEGION_WAR_SUPPLIES,
+    label = L['legion_war_supplies'],
+    note = L['legion_war_supplies_note'],
+    rewards = {
+        Transmog({item = 153339, slot = L['plate']}), -- Triumvirate High Guard's Casque
+        Transmog({item = 153342, slot = L['plate']}), -- Triumvirate High Guard's Pauldrons
+        Transmog({item = 153340, slot = L['plate']}), -- Triumvirate High Guard's Breastplate
+        Transmog({item = 153341, slot = L['plate']}), -- Triumvirate High Guard's Greatbelt
+        Transmog({item = 153338, slot = L['plate']}), -- Triumvirate High Guard's Leggings
+        Transmog({item = 153345, slot = L['plate']}), -- Triumvirate High Guard's Warboots
+        Transmog({item = 153344, slot = L['plate']}), -- Triumvirate High Guard's Bracers
+        Transmog({item = 153343, slot = L['plate']}), -- Triumvirate High Guard's Gauntlets
+        Transmog({item = 152886, slot = L['cloth']}), -- Zealous Felslinger's Visage
+        Transmog({item = 152888, slot = L['cloth']}), -- Zealous Felslinger's Epaulets
+        Transmog({item = 152884, slot = L['cloth']}), -- Zealous Felslinger's Robe
+        Transmog({item = 152881, slot = L['cloth']}), -- Zealous Felslinger's Girdle
+        Transmog({item = 152887, slot = L['cloth']}), -- Zealous Felslinger's Leggings
+        Transmog({item = 152883, slot = L['cloth']}), -- Zealous Felslinger's Boots
+        Transmog({item = 152889, slot = L['cloth']}), -- Zealous Felslinger's Cuffs
+        Transmog({item = 152885, slot = L['cloth']}) -- Zealous Felslinger's Handwraps
+    }
+})
+
+local LWS1 = LWSupplies({quest = 48387, icon = 'chest_pp'})
+local LWS2 = LWSupplies({quest = 48385, icon = 'chest_yw'})
+local LWS3 = LWSupplies({quest = 48390, icon = 'chest_bl'})
+local LWS4 = LWSupplies({quest = 48388, icon = 'chest_rd'})
+local LWS5 = LWSupplies({quest = 48391, icon = 'chest_gn'})
+local LWS6 = LWSupplies({quest = 48382, icon = 'chest_tl'})
+local LWS7 = LWSupplies({quest = 48384, icon = 'chest_pk'})
+local LWS8 = LWSupplies({quest = 48389, icon = 'chest_bn'})
+local LWS9 = LWSupplies({quest = 48383, icon = 'chest_nv'})
+
+map.nodes[65502850] = LWS1
+map.nodes[68903350] = LWS1
+map.nodes[66703630] = LWS1
+map.nodes[63703650] = LWS1
+map.nodes[68004020] = LWS1
+map.nodes[69503950] = LWS1
+map.nodes[72504230] = LWS1
+map.nodes[73504670] = LWS1
+map.nodes[48305440] = LWS2
+map.nodes[50705700] = LWS2
+map.nodes[55504750] = LWS2
+map.nodes[57205120] = LWS2
+map.nodes[56005400] = LWS2
+map.nodes[57805890] = LWS2
+map.nodes[72105680] = LWS3
+map.nodes[78105610] = LWS3
+map.nodes[80506160] = LWS3
+map.nodes[76605820] = LWS3
+map.nodes[76506480] = LWS3
+map.nodes[73406860] = LWS3
+map.nodes[72607270] = LWS3
+map.nodes[77107520] = LWS3
+map.nodes[82506750] = LWS3
+map.nodes[55901400] = LWS4
+map.nodes[59601390] = LWS4
+map.nodes[56001720] = LWS4
+map.nodes[59301770] = LWS4
+map.nodes[55502050] = LWS4
+map.nodes[56002660] = LWS4
+map.nodes[54202790] = LWS4
+map.nodes[51502600] = LWS4
+map.nodes[66604670] = LWS5
+map.nodes[65105070] = LWS5
+map.nodes[68005070] = LWS5
+map.nodes[71105450] = LWS5
+map.nodes[65105510] = LWS5
+map.nodes[63105750] = LWS5
+map.nodes[61305400] = LWS6
+map.nodes[69406350] = LWS6
+map.nodes[71306920] = LWS6
+map.nodes[67606990] = LWS6
+map.nodes[62206950] = LWS6
+map.nodes[57906490] = LWS6
+map.nodes[66601720] = LWS7
+map.nodes[60902900] = LWS7
+map.nodes[59201940] = LWS7
+map.nodes[64002750] = LWS7
+map.nodes[63602110] = LWS7
+map.nodes[61402040] = LWS7
+map.nodes[64305050] = LWS8
+map.nodes[62905000] = LWS8
+map.nodes[64204750] = LWS8
+map.nodes[64204230] = LWS8
+map.nodes[62104580] = LWS8
+map.nodes[60504690] = LWS8
+map.nodes[60604090] = LWS8
+map.nodes[58704330] = LWS8
+map.nodes[52202930] = LWS9
+map.nodes[51803530] = LWS9
+map.nodes[53703570] = LWS9
+map.nodes[55103930] = LWS9
+map.nodes[58204030] = LWS9
+map.nodes[59903580] = LWS9
+map.nodes[58503120] = LWS9
+
+-------------------------------------------------------------------------------
 -------------------------------- MISCELLANEOUS --------------------------------
 -------------------------------------------------------------------------------
 

--- a/plugins/07_Legion/zones/antoran_wastes.lua
+++ b/plugins/07_Legion/zones/antoran_wastes.lua
@@ -16,6 +16,7 @@ local Mount = ns.reward.Mount
 local Pet = ns.reward.Pet
 local Section = ns.reward.Section
 local Toy = ns.reward.Toy
+local Transmog = ns.reward.Transmog
 
 local Path = ns.poi.Path
 local POI = ns.poi.POI
@@ -31,7 +32,18 @@ local map = Map({id = 885, settings = true})
 map.nodes[50905540] = Rare({
     id = 127118,
     quest = 48820,
-    rewards = {Achievement({id = 12078, criteria = 37605})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37605}),
+        Transmog({item = 153312, slot = L['2h_sword']}), -- Praetor's Ornamental Greatsword
+        Transmog({item = 152886, slot = L['cloth']}), -- Zealous Felslinger's Visage
+        Transmog({item = 152888, slot = L['cloth']}), -- Zealous Felslinger's Epaulets
+        Transmog({item = 152884, slot = L['cloth']}), -- Zealous Felslinger's Robe
+        Transmog({item = 152881, slot = L['cloth']}), -- Zealous Felslinger's Girdle
+        Transmog({item = 152887, slot = L['cloth']}), -- Zealous Felslinger's Leggings
+        Transmog({item = 152883, slot = L['cloth']}), -- Zealous Felslinger's Boots
+        Transmog({item = 152889, slot = L['cloth']}), -- Zealous Felslinger's Cuffs
+        Transmog({item = 152885, slot = L['cloth']}) -- Zealous Felslinger's Handwraps
+    }
 }) -- Worldsplitter Skuul
 
 map.nodes[53002930] = Rare({
@@ -52,7 +64,18 @@ map.nodes[53003600] = Rare({
 map.nodes[55302160] = Rare({
     id = 127300,
     quest = 48824,
-    rewards = {Achievement({id = 12078, criteria = 37614})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37614}),
+        Transmog({item = 153319, slot = L['2h_mace']}), -- Ardent Vindicator's Greatmace
+        Transmog({item = 152886, slot = L['cloth']}), -- Zealous Felslinger's Visage
+        Transmog({item = 152888, slot = L['cloth']}), -- Zealous Felslinger's Epaulets
+        Transmog({item = 152884, slot = L['cloth']}), -- Zealous Felslinger's Robe
+        Transmog({item = 152881, slot = L['cloth']}), -- Zealous Felslinger's Girdle
+        Transmog({item = 152887, slot = L['cloth']}), -- Zealous Felslinger's Leggings
+        Transmog({item = 152883, slot = L['cloth']}), -- Zealous Felslinger's Boots
+        Transmog({item = 152889, slot = L['cloth']}), -- Zealous Felslinger's Cuffs
+        Transmog({item = 152885, slot = L['cloth']}) -- Zealous Felslinger's Handwraps
+    }
 }) -- Void Warden Valsuran
 
 map.nodes[55804610] = Rare({
@@ -64,7 +87,18 @@ map.nodes[55804610] = Rare({
 map.nodes[57403350] = Rare({
     id = 122947,
     quest = 49240,
-    rewards = {Achievement({id = 12078, criteria = 37658})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37658}),
+        Transmog({item = 153327, slot = L['dagger']}), -- Mystic Wakener's Dagger
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    }
 }) -- Mistress Il'thendra
 
 map.nodes[58501180] = Rare({
@@ -79,7 +113,9 @@ map.nodes[58501180] = Rare({
 map.nodes[60704800] = Rare({
     id = 126946,
     quest = 48815,
-    rewards = {Achievement({id = 12078, criteria = 37608})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37608}), Item({item = 151543}) -- Technique: Glyph of Fel-Touched Shards
+    }
 }) -- Inquisitor Vethroz
 
 map.nodes[61302130] = Rare({
@@ -181,7 +217,18 @@ map.nodes[66701800] = Rare({
 map.nodes[73607200] = Rare({
     id = 127090,
     quest = 48817,
-    rewards = {Achievement({id = 12078, criteria = 37611})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37611}),
+        Transmog({item = 153324, slot = L['shield']}), -- Eredath Vigilant's Bastion
+        Transmog({item = 152886, slot = L['cloth']}), -- Zealous Felslinger's Visage
+        Transmog({item = 152888, slot = L['cloth']}), -- Zealous Felslinger's Epaulets
+        Transmog({item = 152884, slot = L['cloth']}), -- Zealous Felslinger's Robe
+        Transmog({item = 152881, slot = L['cloth']}), -- Zealous Felslinger's Girdle
+        Transmog({item = 152887, slot = L['cloth']}), -- Zealous Felslinger's Leggings
+        Transmog({item = 152883, slot = L['cloth']}), -- Zealous Felslinger's Boots
+        Transmog({item = 152889, slot = L['cloth']}), -- Zealous Felslinger's Cuffs
+        Transmog({item = 152885, slot = L['cloth']}) -- Zealous Felslinger's Handwraps
+    }
 }) -- Admiral Rel'var
 
 map.nodes[76405590] = Rare({
@@ -195,7 +242,9 @@ map.nodes[84358112] = Rare({
     quest = 48967,
     requires = ns.requirement.Quest(49007), -- Commander On Deck!
     note = L['squadron_commander_vishax_note'],
-    rewards = {Achievement({id = 12078, criteria = 37662})},
+    rewards = {
+        Achievement({id = 12078, criteria = 37662}), Toy({item = 153253}) -- S.F.E. Interceptor
+    },
     pois = {
         POI({77577478}), POI({87788010}), Path({77577478, 87788010, 84358112})
     }
@@ -279,19 +328,28 @@ map.nodes[65903980] = Treasure({
     quest = 49018,
     requires = ns.requirement.Quest(47287), -- The Vindicaar Matrix Core (Light's Judgement)
     note = L['lights_judgement_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37696})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37696}),
+        Transmog({item = 153308, slot = L['1h_mace']}) -- Unyielding Peacekeeper's Cudgel
+    }
 }) -- Ancient Legion War Cache
 
 map.nodes[57406360] = Treasure({
     quest = 49159,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37960})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37960}),
+        Transmog({item = 153285, slot = L['cloth']}) -- Augari Wakener's Mantle
+    }
 }) -- Missing Augari Chest
 
 map.nodes[49005930] = Treasure({
     quest = 49020,
-    rewards = {Achievement({id = 12074, criteria = 37698})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37698}),
+        Transmog({item = 153291, slot = L['staff']}) -- Spectral Censorite's Staff
+    }
 }) -- Legion Treasure Hoard
 
 map.nodes[75705260] = Treasure({

--- a/plugins/07_Legion/zones/eredath.lua
+++ b/plugins/07_Legion/zones/eredath.lua
@@ -14,6 +14,7 @@ local Mount = ns.reward.Mount
 local Pet = ns.reward.Pet
 local Section = ns.reward.Section
 local Toy = ns.reward.Toy
+local Transmog = ns.reward.Transmog
 
 local Path = ns.poi.Path
 local POI = ns.poi.POI
@@ -37,7 +38,8 @@ map.nodes[30104020] = Rare({
     quest = 48709,
     rewards = {
         Achievement({id = 12078, criteria = 37629}),
-        Pet({item = 153056, id = 2120}) -- Grasping Manifestation
+        Pet({item = 153056, id = 2120}), -- Grasping Manifestation
+        Item({item = 153034}) -- Technique: Glyph of the Voidling
     }
 }) -- Ataxon
 
@@ -66,7 +68,8 @@ map.nodes[36702390] = Rare({
     id = 126865,
     quest = 48703,
     rewards = {
-        Achievement({id = 12078, criteria = 37635}), Toy({item = 153183}) -- Barrier Generator
+        Achievement({id = 12078, criteria = 37635}), Toy({item = 153183}), -- Barrier Generator
+        Transmog({item = 153322, slot = L['shield']}) -- Eredath Vigilant's Shield
     }
 }) -- Vigilant Thanos
 
@@ -82,7 +85,10 @@ map.nodes[39106660] = Rare({
     id = 126868,
     quest = 48706,
     note = L['turek_the_lucid_note'],
-    rewards = {Achievement({id = 12078, criteria = 37632})},
+    rewards = {
+        Achievement({id = 12078, criteria = 37632}),
+        Transmog({item = 153306, slot = L['1h_axe']}) -- Oronaar Miner's Piercer
+    },
     pois = {POI({39106665})}
 }) -- Turek the Lucid
 
@@ -119,13 +125,19 @@ map.nodes[43806040] = Rare({
 map.nodes[44507170] = Rare({
     id = 122838,
     quest = 48692,
-    rewards = {Achievement({id = 12078, criteria = 37654})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37654}),
+        Transmog({item = 153296, slot = L['1h_sword']}) -- Spectral Consul's Cutter
+    }
 }) -- Shadowcaster Voruun
 
 map.nodes[48104060] = Rare({
     id = 126899,
     quest = 48713,
-    rewards = {Achievement({id = 12078, criteria = 37625})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37625}),
+        Transmog({item = 153302, slot = L['1h_sword']}) -- Honed Jed'hin Scimitar
+    }
 }) -- Jed'hin Champion Vorusk
 
 map.nodes[48805200] = Rare({
@@ -141,9 +153,9 @@ map.nodes[49800930] = Rare({
     quest = 48721,
     rewards = {
         Achievement({id = 12078, criteria = 37618}),
-        Mount({item = 152904, id = 980})
+        Mount({item = 152904, id = 980}) -- Acid Belcher
     }
-}) -- Skreeg the Devourer (Acid Belcher)
+}) -- Skreeg the Devourer
 
 map.nodes[52906760] = Rare({
     id = 126815,
@@ -151,11 +163,12 @@ map.nodes[52906760] = Rare({
     rewards = {Achievement({id = 12078, criteria = 37640})}
 }) -- Soultwisted Monstrosity
 
-map.nodes[53906440] = Rare({
+map.nodes[63806460] = Rare({
     id = 126866,
     quest = 48704,
     rewards = {
-        Achievement({id = 12078, criteria = 37634}), Toy({item = 153183}) -- Barrier Generator
+        Achievement({id = 12078, criteria = 37634}), Toy({item = 153183}), -- Barrier Generator
+        Transmog({item = 153323, slot = L['shield']}) -- Eredath Vigilant's Crest
     }
 }) -- Vigilant Kuro
 
@@ -164,7 +177,8 @@ map.nodes[55506010] = Rare({
     quest = 48965,
     rewards = {
         Achievement({id = 12078, criteria = 37639}),
-        Mount({item = 152814, id = 970}) -- Maddened Chaosrunner
+        Mount({item = 152814, id = 970}), -- Maddened Chaosrunner
+        Transmog({item = 153269, slot = L['1h_axe']}) -- Enclave Aspirant's Waraxe
     }
 }) -- Wrangler Kravos
 
@@ -177,19 +191,28 @@ map.nodes[56901460] = Rare({
 map.nodes[57002780] = Rare({
     id = 125497,
     quest = 48716,
-    rewards = {Achievement({id = 12078, criteria = 37623})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37623}),
+        Transmog({item = 153269, slot = L['1h_axe']}) -- Enclave Aspirant's Axe
+    }
 }) -- Overseer Y'Sorna
 
 map.nodes[58903760] = Rare({
     id = 124440,
     quest = 48714,
-    rewards = {Achievement({id = 12078, criteria = 37624})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37624}),
+        Transmog({item = 153315, slot = L['2h_sword']}) -- Praetor's Ornamental Warblade
+    }
 }) -- Overseer Y'Beda
 
 map.nodes[61002980] = Rare({
     id = 125498,
     quest = 48717,
-    rewards = {Achievement({id = 12078, criteria = 37622})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37622}),
+        Transmog({item = 153257, slot = L['1h_mace']}) -- Isolon Anchorite's Gavel
+    }
 }) -- Overseer Y'Morna
 
 map.nodes[61405040] = Rare({
@@ -198,7 +221,8 @@ map.nodes[61405040] = Rare({
     rewards = {
         Achievement({id = 12078, criteria = 37621}), Toy({item = 153179}), -- Blue Conservatory Scroll
         Toy({item = 153181}), -- Red Conservatory Scroll
-        Toy({item = 153180}) -- Yellow Conservatory Scroll
+        Toy({item = 153180}), -- Yellow Conservatory Scroll
+        Transmog({item = 153309, slot = L['1h_mace']}) -- Unyielding Peacekeeper's Mace
     }
 }) -- Instructor Tarahna
 
@@ -212,7 +236,10 @@ map.nodes[66812841] = Rare({
 map.nodes[70204600] = Rare({
     id = 126889,
     quest = 48710,
-    rewards = {Achievement({id = 12078, criteria = 37628})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37628}),
+        Transmog({item = 153292, slot = L['1h_mace']}) -- Spectral Censorite's Spire
+    }
 }) -- Sorolis the Ill-Fated
 
 -------------------------------------------------------------------------------
@@ -223,7 +250,10 @@ map.nodes[40205140] = Treasure({
     quest = 48747,
     requires = ns.requirement.Quest(47994), -- Forming a Bond (Lightforged Warframe)
     note = L['lightforged_warframe_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37598})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37598}),
+        Transmog({item = 153328, slot = L['dagger']}) -- Mystic Wakener's Shiv
+    }
 }) -- Void-Tinged Chest
 
 map.nodes[43400450] = Treasure({
@@ -237,35 +267,50 @@ map.nodes[50603840] = Treasure({
     quest = 48744,
     requires = ns.requirement.Quest(47287), -- The Vindicaar Matrix Core (Light's Judgement)
     note = L['lights_judgement_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37596})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37596}),
+        Transmog({item = 153325, slot = L['shield']}) -- Eredath Vigilant's Redoubt
+    }
 }) -- Chest of Ill-Gotten Gains
 
 map.nodes[62207120] = Treasure({
     quest = 48745,
     requires = ns.requirement.Quest(47287), -- The Vindicaar Matrix Core (Light's Judgement)
     note = L['lights_judgement_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37597})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37597}),
+        Transmog({item = 153286, slot = L['cloth']}) -- Augari Wakener's Cuffs
+    }
 }) -- Student's Surprising Surplus
 
 map.nodes[40806980] = Treasure({
     quest = 49153,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37957})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37957}),
+        Transmog({item = 153281, slot = L['cloth']}) -- Augari Wakener's Handwraps
+    }
 }) -- Augari Goods
 
 map.nodes[62202240] = Treasure({
     quest = 49151,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37956})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37956}),
+        Transmog({item = 153282, slot = L['cloth']}) -- Augari Wakener's Leggings
+    }
 }) -- Secret Augari Chest
 
 map.nodes[70602730] = Treasure({
     quest = 49129,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37955})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37955}),
+        Transmog({item = 153280, slot = L['cloth']}) -- Augari Wakener's Circlet
+    }
 }) -- Augari-Runed Chest
 
 map.nodes[27304010] = Treasure({
@@ -278,19 +323,28 @@ map.nodes[27304010] = Treasure({
 map.nodes[43395443] = Treasure({
     quest = 48751,
     note = L['goblin_glider_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37602})},
+    rewards = {
+        Achievement({id = 12074, criteria = 37602}),
+        Transmog({item = 153313, slot = L['2h_sword']}) -- Praetor's Ornamental Claymore
+    },
     pois = {POI({45105310}), Path({45105310, 43395443})}
 }) -- Doomseeker's Treasure
 
 map.nodes[70305976] = Treasure({
     quest = 48748,
     note = L['goblin_glider_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37599})},
+    rewards = {
+        Achievement({id = 12074, criteria = 37599}),
+        Transmog({item = 153279, slot = L['cloth']}) -- Augari Wakener's Cord
+    },
     pois = {POI({68075723}), Path({68075723, 70305976})}
 }) -- Augari Secret Stash
 
 map.nodes[57027686] = Treasure({
     quest = 48749,
-    rewards = {Achievement({id = 12074, criteria = 37600})},
+    rewards = {
+        Achievement({id = 12074, criteria = 37600}),
+        Transmog({item = 153267, slot = L['2h_sword']}) -- Enclave Aspirant's Hatchet
+    },
     pois = {POI({57087407}), Path({57087407, 57117525, 57627617, 57027686})}
 }) -- Desperate Eredar's Cache

--- a/plugins/07_Legion/zones/eredath.lua
+++ b/plugins/07_Legion/zones/eredath.lua
@@ -2,6 +2,7 @@
 ---------------------------------- NAMESPACE ----------------------------------
 -------------------------------------------------------------------------------
 local ADDON_NAME, ns = ...
+local Class = ns.Class
 local L = ns.locale
 local Map = ns.Map
 
@@ -238,7 +239,7 @@ map.nodes[70204600] = Rare({
     quest = 48710,
     rewards = {
         Achievement({id = 12078, criteria = 37628}),
-        Transmog({item = 153292, slot = L['1h_mace']}) -- Spectral Censorite's Spire
+        Transmog({item = 153292, slot = L['staff']}) -- Spectral Censorite's Spire
     }
 }) -- Sorolis the Ill-Fated
 
@@ -348,3 +349,167 @@ map.nodes[57027686] = Treasure({
     },
     pois = {POI({57087407}), Path({57087407, 57117525, 57627617, 57027686})}
 }) -- Desperate Eredar's Cache
+
+-------------------------------------------------------------------------------
+------------------------------ DAILY CHESTS -----------------------------------
+-------------------------------------------------------------------------------
+
+local AECache = Class('AECache', Treasure, {
+    group = ns.groups.ANCIENT_EREDAR_CACHE,
+    label = L['ancient_eredar_cache'],
+    note = L['ancient_eredar_cache_note'],
+    requires = ns.requirement.Quest(48107), -- The Sigil of Awakening
+    rewards = {
+        Transmog({item = 153331, slot = L['plate']}), -- Eredath Lightseeker's Helmet
+        Transmog({item = 153334, slot = L['plate']}), -- Eredath Lightseeker's Spaulders
+        Transmog({item = 153332, slot = L['plate']}), -- Eredath Lightseeker's Chestpiece
+        Transmog({item = 153333, slot = L['plate']}), -- Eredath Lightseeker's Waistplate
+        Transmog({item = 153330, slot = L['plate']}), -- Eredath Lightseeker's Greaves
+        Transmog({item = 153337, slot = L['plate']}), -- Eredath Lightseeker's Treads
+        Transmog({item = 153336, slot = L['plate']}), -- Eredath Lightseeker's Armguards
+        Transmog({item = 153335, slot = L['plate']}), -- Eredath Lightseeker's Handguards
+        Transmog({item = 153271, slot = L['cloth']}), -- Forgotten Conservatory Helm
+        Transmog({item = 153276, slot = L['cloth']}), -- Forgotten Conservatory Amice
+        Transmog({item = 153288, slot = L['cloth']}), -- Forgotten Conservatory Robes
+        Transmog({item = 153270, slot = L['cloth']}), -- Forgotten Conservatory Sash
+        Transmog({item = 153273, slot = L['cloth']}), -- Forgotten Conservatory Leggings
+        Transmog({item = 153275, slot = L['cloth']}), -- Forgotten Conservatory Slippers
+        Transmog({item = 153277, slot = L['cloth']}), -- Forgotten Conservatory Wristwraps
+        Transmog({item = 153272, slot = L['cloth']}) -- Forgotten Conservatory Gloves
+    }
+})
+
+local AEC1 = AECache({quest = 48346, icon = 'chest_pp'})
+local AEC2 = AECache({quest = 48350, icon = 'chest_yw'})
+local AEC3 = AECache({quest = 48351, icon = 'chest_bl'})
+local AEC4 = AECache({quest = 48362, icon = 'chest_rd'})
+local AEC5 = AECache({quest = 48357, icon = 'chest_gn'})
+local AEC6 = AECache({quest = 48371, icon = 'chest_tl'})
+
+map.nodes[47106250] = AEC1
+map.nodes[54905770] = AEC1
+map.nodes[52706180] = AEC1
+map.nodes[57506160] = AEC1
+map.nodes[59506390] = AEC1
+map.nodes[50906720] = AEC1
+map.nodes[54706690] = AEC1
+map.nodes[60907060] = AEC1
+map.nodes[51807140] = AEC1
+map.nodes[50107600] = AEC1
+map.nodes[52908250] = AEC1
+map.nodes[57507510] = AEC1
+map.nodes[55207790] = AEC1
+map.nodes[58704070] = AEC2
+map.nodes[53603420] = AEC2
+map.nodes[60603340] = AEC2
+map.nodes[53502750] = AEC2
+map.nodes[62202650] = AEC2
+map.nodes[53902320] = AEC2
+map.nodes[59502090] = AEC2
+map.nodes[63301990] = AEC2
+map.nodes[47707330] = AEC3
+map.nodes[44606860] = AEC3
+map.nodes[41106890] = AEC3
+map.nodes[38506690] = AEC3
+map.nodes[36406630] = AEC3
+map.nodes[34206560] = AEC3
+map.nodes[37106260] = AEC3
+map.nodes[41606340] = AEC3
+map.nodes[43506010] = AEC3
+map.nodes[42605380] = AEC3
+map.nodes[40505550] = AEC3
+map.nodes[37905870] = AEC3
+map.nodes[37305550] = AEC3
+map.nodes[34105730] = AEC3
+map.nodes[66502890] = AEC4
+map.nodes[67903190] = AEC4
+map.nodes[70103380] = AEC4
+map.nodes[68803710] = AEC4
+map.nodes[65303560] = AEC4
+map.nodes[62203270] = AEC4
+map.nodes[68504150] = AEC4
+map.nodes[65504190] = AEC4
+map.nodes[61904270] = AEC4
+map.nodes[59804660] = AEC4
+map.nodes[63804530] = AEC4
+map.nodes[67204620] = AEC4
+map.nodes[69504490] = AEC4
+map.nodes[69704940] = AEC4
+map.nodes[62705060] = AEC4
+map.nodes[61505550] = AEC4
+map.nodes[64605590] = AEC4
+map.nodes[65906010] = AEC4
+map.nodes[68505310] = AEC4
+map.nodes[58701330] = AEC5
+map.nodes[58001060] = AEC5
+map.nodes[53300860] = AEC5
+map.nodes[53501300] = AEC5
+map.nodes[53001690] = AEC5
+map.nodes[54901740] = AEC5
+map.nodes[50001420] = AEC5
+map.nodes[48401290] = AEC5
+map.nodes[45101350] = AEC5
+map.nodes[44701850] = AEC5
+map.nodes[42601780] = AEC5
+map.nodes[48602100] = AEC5
+map.nodes[45102480] = AEC5
+map.nodes[49902930] = AEC5
+map.nodes[51702870] = AEC5
+map.nodes[19704210] = AEC6
+map.nodes[24603860] = AEC6
+map.nodes[25503000] = AEC6
+map.nodes[29003380] = AEC6
+map.nodes[32604700] = AEC6
+map.nodes[47103660] = AEC6
+map.nodes[49503580] = AEC6
+map.nodes[49804160] = AEC6
+map.nodes[53604200] = AEC6
+map.nodes[54704480] = AEC6
+map.nodes[51004780] = AEC6
+map.nodes[48704980] = AEC6
+map.nodes[50605580] = AEC6
+map.nodes[59305870] = AEC6
+
+-------------------------------------------------------------------------------
+
+local VSCache = Class('VSCache', Treasure, {
+    group = ns.groups.VOID_SEEPED_CACHE,
+    label = L['void_seeped_cache'],
+    note = L['void_seeped_cache_note'],
+    requires = ns.requirement.Quest(48107) -- The Sigil of Awakening
+})
+
+local VSC1 = VSCache({quest = 48361, icon = 'chest_pk'})
+local VSC2 = VSCache({quest = 49264, icon = 'chest_nv'})
+
+map.nodes[35403600] = VSC1
+map.nodes[37704230] = VSC1
+map.nodes[40504810] = VSC1
+map.nodes[37804840] = VSC1
+map.nodes[35404690] = VSC1
+map.nodes[33304350] = VSC1
+map.nodes[29605030] = VSC1
+map.nodes[28904420] = VSC1
+map.nodes[29503990] = VSC1
+map.nodes[27503950] = VSC1
+map.nodes[25403490] = VSC1
+map.nodes[24804150] = VSC1
+map.nodes[25904460] = VSC1
+map.nodes[26604880] = VSC1
+map.nodes[26505190] = VSC1
+map.nodes[24305670] = VSC1
+map.nodes[22604470] = VSC1
+map.nodes[19904650] = VSC1
+map.nodes[20804050] = VSC1
+map.nodes[18904140] = VSC1
+map.nodes[37002010] = VSC2
+map.nodes[37902350] = VSC2
+map.nodes[37603630] = VSC2
+map.nodes[38103990] = VSC2
+map.nodes[35303860] = VSC2
+map.nodes[34503570] = VSC2
+map.nodes[33202960] = VSC2
+map.nodes[31602540] = VSC2
+map.nodes[33602380] = VSC2
+map.nodes[34102070] = VSC2
+map.nodes[32502140] = VSC2

--- a/plugins/07_Legion/zones/eredath.lua
+++ b/plugins/07_Legion/zones/eredath.lua
@@ -175,7 +175,7 @@ map.nodes[63806460] = Rare({
 
 map.nodes[55506010] = Rare({
     id = 126852,
-    quest = 48965,
+    quest = 48695,
     rewards = {
         Achievement({id = 12078, criteria = 37639}),
         Mount({item = 152814, id = 970}), -- Maddened Chaosrunner

--- a/plugins/07_Legion/zones/krokuun.lua
+++ b/plugins/07_Legion/zones/krokuun.lua
@@ -13,6 +13,7 @@ local Mount = ns.reward.Mount
 local Pet = ns.reward.Pet
 local Section = ns.reward.Section
 local Toy = ns.reward.Toy
+local Transmog = ns.reward.Transmog
 
 local POI = ns.poi.POI
 
@@ -33,13 +34,35 @@ map.nodes[33307620] = Rare({
 map.nodes[38305980] = Rare({
     id = 122911,
     quest = 48563,
-    rewards = {Achievement({id = 12078, criteria = 37643})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37643}),
+        Transmog({item = 153299, slot = L['1h_sword']}), -- Militant Exarch's Shortsword
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    }
 }) -- Commander Vecaya
 
 map.nodes[40704340] = Rare({
     id = 125824,
     quest = 48561,
-    rewards = {Achievement({id = 12078, criteria = 37646})},
+    rewards = {
+        Achievement({id = 12078, criteria = 37646}),
+        Transmog({item = 153316, slot = L['2h_sword']}), -- Praetor's Ornamental Edge
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    },
     pois = {POI({50201710})}
 }) -- Khazaduum
 
@@ -52,7 +75,18 @@ map.nodes[42406990] = Rare({
 map.nodes[45305890] = Rare({
     id = 124775,
     quest = 48564,
-    rewards = {Achievement({id = 12078, criteria = 37642})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37642}),
+        Transmog({item = 153255, slot = L['1h_mace']}), -- Isolon Anchorite's Cudgel
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    }
 }) -- Commander Endaxis
 
 map.nodes[52803110] = Rare({
@@ -66,7 +100,18 @@ map.nodes[52803110] = Rare({
 map.nodes[54708120] = Rare({
     id = 123689,
     quest = 48628,
-    rewards = {Achievement({id = 12078, criteria = 37655})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37655}),
+        Transmog({item = 153329, slot = L['dagger']}), -- Mystic Wakener's Blade
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    }
 }) -- Talestra the Vile
 
 map.nodes[58407610] = Rare({
@@ -78,13 +123,26 @@ map.nodes[58407610] = Rare({
 map.nodes[60901960] = Rare({
     id = 125388,
     quest = 48629,
-    rewards = {Achievement({id = 12078, criteria = 37652})}
+    rewards = {
+        Achievement({id = 12078, criteria = 37652}), Item({item = 153114}) -- Nathrezim Tome of Manipulation
+    }
 }) -- Vagath the Betrayed
 
 map.nodes[69405740] = Rare({
     id = 124804,
     quest = 48664,
-    rewards = {Achievement({id = 12078, criteria = 37653})},
+    rewards = {
+        Achievement({id = 12078, criteria = 37653}),
+        Transmog({item = 153263, slot = L['1h_axe']}), -- Enclave Aspirant's Cleaver
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    },
     pois = {POI({69305940})}
 }) -- Tereck the Selector
 
@@ -118,7 +176,10 @@ map.nodes[51307620] = Treasure({
     quest = 48884,
     requires = ns.requirement.Quest(47994), -- Forming a Bond (Lightforged Warframe)
     note = L['lightforged_warframe_treasure_note'],
-    rewards = {Achievement({id = 12074, criteria = 37592})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37592}),
+        Transmog({item = 153304, slot = L['1h_axe']}) -- Oronaar Miner's Dredger
+    }
 }) -- Krokul Emergency Cache
 
 map.nodes[48505890] = Treasure({
@@ -139,12 +200,18 @@ map.nodes[55907410] = Treasure({
     quest = 49156,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37959})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37959}),
+        Transmog({item = 153283, slot = L['cloth']}) -- Augari Wakener's Vestments
+    }
 }) -- Precious Augari Keepsakes
 
 map.nodes[75106980] = Treasure({
     quest = 49154,
     requires = ns.requirement.Quest(48107), -- The Sigil of Awakening (Shroud of Arcane Echoes)
     note = L['shroud_of_arcane_echoes_treasures_note'],
-    rewards = {Achievement({id = 12074, criteria = 37958})}
+    rewards = {
+        Achievement({id = 12074, criteria = 37958}),
+        Transmog({item = 153284, slot = L['cloth']}) -- Augari Wakener's Treads
+    }
 }) -- Long-Lost Augari Treasure

--- a/plugins/07_Legion/zones/krokuun.lua
+++ b/plugins/07_Legion/zones/krokuun.lua
@@ -50,7 +50,7 @@ map.nodes[38305980] = Rare({
     }
 }) -- Commander Vecaya
 
-map.nodes[40704340] = Rare({
+map.nodes[44000700] = Rare({
     id = 125824,
     quest = 48561,
     rewards = {

--- a/plugins/07_Legion/zones/krokuun.lua
+++ b/plugins/07_Legion/zones/krokuun.lua
@@ -2,6 +2,7 @@
 ---------------------------------- NAMESPACE ----------------------------------
 -------------------------------------------------------------------------------
 local ADDON_NAME, ns = ...
+local Class = ns.Class
 local L = ns.locale
 local Map = ns.Map
 
@@ -9,6 +10,7 @@ local Treasure = ns.node.Treasure
 local Rare = ns.node.Rare
 
 local Achievement = ns.reward.Achievement
+local Item = ns.reward.Item
 local Mount = ns.reward.Mount
 local Pet = ns.reward.Pet
 local Section = ns.reward.Section
@@ -215,3 +217,133 @@ map.nodes[75106980] = Treasure({
         Transmog({item = 153284, slot = L['cloth']}) -- Augari Wakener's Treads
     }
 }) -- Long-Lost Augari Treasure
+
+-------------------------------------------------------------------------------
+------------------------------ DAILY CHESTS -----------------------------------
+-------------------------------------------------------------------------------
+
+local EWSupplies = Class('EWSupplies', Treasure, {
+    group = ns.groups.EREDAR_WAR_SUPPLIES,
+    label = L['eredar_war_supplies'],
+    note = L['eredar_war_supplies_note'],
+    rewards = {
+        Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
+        Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates
+        Transmog({item = 152949, slot = L['plate']}), -- World-Defiler's Cuirass
+        Transmog({item = 152943, slot = L['plate']}), -- World-Defiler's Girdle
+        Transmog({item = 152945, slot = L['plate']}), -- World-Defiler's Tuille
+        Transmog({item = 152948, slot = L['plate']}), -- World-Defiler's Sabatons
+        Transmog({item = 152942, slot = L['plate']}), -- World-Defiler's Wristguards
+        Transmog({item = 152947, slot = L['plate']}) -- World-Defiler's Gauntlets
+    }
+})
+
+local EWS1 = EWSupplies({quest = 48339, icon = 'chest_pp'}) -- object ID 272771
+local EWS2 = EWSupplies({quest = 47999, icon = 'chest_yw'}) -- object ID 272456
+local EWS3 = EWSupplies({quest = 48000, icon = 'chest_bl'}) -- object ID 273222
+local EWS4 = EWSupplies({quest = 47753, icon = 'chest_rd'}) -- object ID 271849
+local EWS5 = EWSupplies({quest = 47752, icon = 'chest_gn'}) -- object ID 272455
+local EWS6 = EWSupplies({quest = 48336, icon = 'chest_tl'}) -- object ID 272770
+local EWS7 = EWSupplies({quest = 47997, icon = 'chest_pk'}) -- object ID 271850
+
+map.nodes[73503450] = EWS1
+map.nodes[70503080] = EWS1
+map.nodes[66003520] = EWS1
+map.nodes[68503880] = EWS1
+map.nodes[63104250] = EWS1
+map.nodes[61306650] = EWS1
+map.nodes[53906770] = EWS1
+map.nodes[52906270] = EWS1
+map.nodes[50106670] = EWS1
+map.nodes[46206190] = EWS1
+map.nodes[50106670] = EWS1
+map.nodes[45805850] = EWS1
+map.nodes[43605550] = EWS1
+map.nodes[43505090] = EWS1
+map.nodes[46504910] = EWS1
+map.nodes[44904350] = EWS1
+map.nodes[47604200] = EWS1
+map.nodes[46303630] = EWS2
+map.nodes[47702890] = EWS2
+map.nodes[49103350] = EWS2
+map.nodes[49803670] = EWS2
+map.nodes[51103210] = EWS2
+map.nodes[52003670] = EWS2
+map.nodes[53903050] = EWS2
+map.nodes[55903680] = EWS2
+map.nodes[57503270] = EWS2
+map.nodes[58303630] = EWS2
+map.nodes[59703950] = EWS2
+map.nodes[59604420] = EWS2
+map.nodes[62504160] = EWS2
+map.nodes[62803800] = EWS2
+map.nodes[61503590] = EWS2
+map.nodes[59503280] = EWS2
+map.nodes[62303210] = EWS2
+map.nodes[60802870] = EWS2
+map.nodes[57702620] = EWS2
+map.nodes[60502370] = EWS2
+map.nodes[59201880] = EWS2
+map.nodes[62502580] = EWS2
+map.nodes[65902300] = EWS2
+map.nodes[69805770] = EWS3
+map.nodes[68806210] = EWS3
+map.nodes[71906170] = EWS3
+map.nodes[72806490] = EWS3
+map.nodes[75106450] = EWS3
+map.nodes[74106780] = EWS3
+map.nodes[73507130] = EWS3
+map.nodes[71807550] = EWS3
+map.nodes[69807840] = EWS3
+map.nodes[69208410] = EWS3
+map.nodes[67907150] = EWS3
+map.nodes[63006820] = EWS3
+map.nodes[52707610] = EWS4
+map.nodes[53107310] = EWS4
+map.nodes[55208110] = EWS4
+map.nodes[58507980] = EWS4
+map.nodes[60207600] = EWS4
+map.nodes[59307330] = EWS4
+map.nodes[58207180] = EWS4
+map.nodes[56807220] = EWS4
+map.nodes[59705220] = EWS5
+map.nodes[58505060] = EWS5
+map.nodes[57005470] = EWS5
+map.nodes[55505230] = EWS5
+map.nodes[55505850] = EWS5
+map.nodes[53305100] = EWS5
+map.nodes[52205420] = EWS5
+map.nodes[50405130] = EWS5
+map.nodes[52005960] = EWS5
+map.nodes[49605880] = EWS5
+map.nodes[36907430] = EWS6
+map.nodes[36506760] = EWS6
+map.nodes[37106410] = EWS6
+map.nodes[40606070] = EWS6
+map.nodes[40505550] = EWS6
+map.nodes[38905910] = EWS6
+map.nodes[36605890] = EWS6
+map.nodes[35405620] = EWS6
+map.nodes[33605530] = EWS6
+map.nodes[29605770] = EWS6
+map.nodes[30306410] = EWS6
+map.nodes[31906760] = EWS6
+map.nodes[32107460] = EWS6
+map.nodes[28307130] = EWS6
+map.nodes[26106810] = EWS6
+map.nodes[49807580] = EWS7
+map.nodes[48307370] = EWS7
+map.nodes[45907300] = EWS7
+map.nodes[45906790] = EWS7
+map.nodes[43806970] = EWS7
+map.nodes[43806700] = EWS7
+map.nodes[40407400] = EWS7
+map.nodes[42707550] = EWS7
+map.nodes[45907750] = EWS7
+map.nodes[41107990] = EWS7
+map.nodes[44008130] = EWS7
+map.nodes[46807980] = EWS7
+map.nodes[46508520] = EWS7
+map.nodes[44208640] = EWS7
+map.nodes[42508770] = EWS7
+map.nodes[41608380] = EWS7

--- a/plugins/07_Legion/zones/krokuun.lua
+++ b/plugins/07_Legion/zones/krokuun.lua
@@ -226,6 +226,7 @@ local EWSupplies = Class('EWSupplies', Treasure, {
     group = ns.groups.EREDAR_WAR_SUPPLIES,
     label = L['eredar_war_supplies'],
     note = L['eredar_war_supplies_note'],
+    requires = ns.requirement.Quest(48199), -- The Burning Heart
     rewards = {
         Transmog({item = 152946, slot = L['plate']}), -- World-Defiler's Casque
         Transmog({item = 152944, slot = L['plate']}), -- World-Defiler's Shoulderplates


### PR DESCRIPTION
## Bugfixes
1. Fixed the coordinate of Vigilant Kuro on map Eredath.
2. Squadron Commander Vishax should drop the toy S.F.E. Interceptor.
3. Fixed Wrangler Kravos' tracking quest ID.
4. Fixed the coordinate of Khazaduum on map Krokuun.

## Features
1. Show transmog loots for Argus rares and treasures.
2. Add the options to show daily chests on Argus maps.