### PR TITLE
Fix wrong expansion name for WoD in README.md

### DIFF
--- a/plugins/06_WarlordsOfDraenor/README.md
+++ b/plugins/06_WarlordsOfDraenor/README.md
@@ -1,4 +1,4 @@
-A [HandyNotes](https://www.curseforge.com/wow/addons/handynotes) plugin for the Shadowlands expansion. It will add the locations and rewards for rare mobs, battle pets, treasures and other miscellaneous points of interest to the map.
+A [HandyNotes](https://www.curseforge.com/wow/addons/handynotes) plugin for the Warlords of Draenor expansion. It will add the locations and rewards for rare mobs, battle pets, treasures and other miscellaneous points of interest to the map.
 
 ## Global Features
 


### PR DESCRIPTION
The README for WoD expansion says it's for Shadowlands :)