### PR TITLE
Patch 10.2 Update Emerald Bounty Loot and Notes

### DIFF
--- a/plugins/10_Dragonflight/localization/deDE.lua
+++ b/plugins/10_Dragonflight/localization/deDE.lua
@@ -897,11 +897,14 @@ L['plush_pillow_note'] = 'In der kleinen Hütte auf einem Tisch.'
 L['snuggle_buddy_note'] = 'In einem kleinen Boot.'
 
 L['dreamseed_soil_label'] = '{npc:210723}' -- Traumsaaterde
-L['dreamseed_soil_note'] = [[
-Du kannst  {currency:2651}, {item:210651} und Kosmetische Gegenstände nur erhalten, wenn du eine Traumsaat beisteuerst oder pflanzt. Die Menge der {currency:2651} hängt von der Qualität der Saat ab.
+L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+-- L['dreamseed_soil_note'] = [[
+-- Du kannst  {currency:2651}, {item:210651} und Kosmetische Gegenstände nur erhalten, wenn du eine Traumsaat beisteuerst oder pflanzt. Die Menge der {currency:2651} hängt von der Qualität der Saat ab.
 
-Wenn du {currency:2650} beisteuerst, erhältst du eine kleine Menge an Handwerksmaterialien und {currency:2245}.
-]]
+-- Wenn du {currency:2650} beisteuerst, erhältst du eine kleine Menge an Handwerksmaterialien und {currency:2245}.
+-- ]]
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = 'Zeigt die Positionen der {npc:210723} für den Erfolg {achievement:19013} an.'
 

--- a/plugins/10_Dragonflight/localization/enUS.lua
+++ b/plugins/10_Dragonflight/localization/enUS.lua
@@ -896,7 +896,7 @@ L['plush_pillow_note'] = 'Inside the little hut on a table.'
 L['snuggle_buddy_note'] = 'Inside a small boat.'
 
 L['dreamseed_soil_label'] = 'Dreamseed Soil'
-L['dreamseed_soil_note'] = 'Contribution progress of {currency:2650}, determines the quality of Emerald Bloom。\nIts quality affects the probability of {item:210059} being found in {object:Dreamseed Cache}.\n{item:210224} (Once at least)\n{item:210225} (Progress: 50%)\n{item:210226} (Progress: 100%)\n\nQuality of Dreamseed defines what kind of reward.\n{item:208066}: A Transmog or crafting materials\n{item:208067}: A Pet or crafting materials\n{item:208047}: A Mount or crafting materials'
+L['dreamseed_soil_note'] = 'Contribution progress of {currency:2650}, determines the quality of {item:201467}.\nIts quality affects the probability of {item:210059} being found in {object:Dreamseed Cache}.\n{item:210224} (Once at least)\n{item:210225} (Progress: 50%)\n{item:210226} (Progress: 100%)\n\nQuality of {object:Dreamseed} defines the kind of reward.\n{item:208066}: A transmog or crafting materials.\n{item:208067}: A pet or crafting materials.\n{item:208047}: A mount or crafting materials.'
 L['dreamseed_cache'] = 'Dreamseed Cache'
 
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'

--- a/plugins/10_Dragonflight/localization/enUS.lua
+++ b/plugins/10_Dragonflight/localization/enUS.lua
@@ -896,11 +896,9 @@ L['plush_pillow_note'] = 'Inside the little hut on a table.'
 L['snuggle_buddy_note'] = 'Inside a small boat.'
 
 L['dreamseed_soil_label'] = 'Dreamseed Soil'
-L['dreamseed_soil_note'] = [[
-You can only get {currency:2651}, {item:210651} and cosmetics if you contribute or plant a Dreamseed, the amount of {currency:2651} depends on the quality of the seed.
+L['dreamseed_soil_note'] = 'Contribution progress of {currency:2650}, determines the quality of Emerald Bloom。\nIts quality affects the probability of {item:210059} being found in {object:Dreamseed Cache}.\n{item:210224} (Once at least)\n{item:210225} (Progress: 50%)\n{item:210226} (Progress: 100%)\n\nQuality of Dreamseed defines what kind of reward.\n{item:208066}: A Transmog or crafting materials\n{item:208067}: A Pet or crafting materials\n{item:208047}: A Mount or crafting materials'
+L['dreamseed_cache'] = 'Dreamseed Cache'
 
-If you contribute {currency:2650}, you will receive a small amount of crafting materials and {currency:2245s}.
-]] -- is there only 1 pet? will it drop from any seed?
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = 'Display {object:Dreamseed Soil} locations for {achievement:19013}.'
 

--- a/plugins/10_Dragonflight/localization/esES.lua
+++ b/plugins/10_Dragonflight/localization/esES.lua
@@ -896,11 +896,14 @@ L['plush_pillow_note'] = 'Dentro de la choza pequeña y encima de una mesa.'
 L['snuggle_buddy_note'] = 'Dentro de un bote pequeño.'
 
 L['dreamseed_soil_label'] = 'Tierra con Semillas del Sueño'
-L['dreamseed_soil_note'] = [[
-Sólo puedes conseguir {currency:2651}, {item:210651} y cosméticos si contribuyes o plantas una Semilla del Sueño. La cantidad de {currency:2651} depende de la calidad de la semilla.
+L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+-- L['dreamseed_soil_note'] = [[
+-- Sólo puedes conseguir {currency:2651}, {item:210651} y cosméticos si contribuyes o plantas una Semilla del Sueño. La cantidad de {currency:2651} depende de la calidad de la semilla.
 
-Si contribuyes con {currency:2650}, recibirás una pequeña cantidad de materiales de artesanía y {currency:2245}.
-]]
+-- Si contribuyes con {currency:2650}, recibirás una pequeña cantidad de materiales de artesanía y {currency:2245}.
+-- ]]
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = 'Muestra dónde están las {object:Tierra con Semillas del Sueño} para el logro {achievement:19013}.'
 

--- a/plugins/10_Dragonflight/localization/esES.lua
+++ b/plugins/10_Dragonflight/localization/esES.lua
@@ -896,13 +896,8 @@ L['plush_pillow_note'] = 'Dentro de la choza pequeña y encima de una mesa.'
 L['snuggle_buddy_note'] = 'Dentro de un bote pequeño.'
 
 L['dreamseed_soil_label'] = 'Tierra con Semillas del Sueño'
-L['dreamseed_soil_note'] = nil
-L['dreamseed_cache'] = nil
--- L['dreamseed_soil_note'] = [[
--- Sólo puedes conseguir {currency:2651}, {item:210651} y cosméticos si contribuyes o plantas una Semilla del Sueño. La cantidad de {currency:2651} depende de la calidad de la semilla.
-
--- Si contribuyes con {currency:2650}, recibirás una pequeña cantidad de materiales de artesanía y {currency:2245}.
--- ]]
+L['dreamseed_soil_note'] = 'La contribución al progreso de {currency:2650}, determina la calidad de la {item:201467}.\nSu calidad afecta a la probabilidad de encontrar las {item:210059} en un {object:Alijo de semillas del Sueño}.\n{item:210224} (Al menos una vez)\n{item:210225} (Progreso: 50%)\n{item:210226} (Progreso: 100%)\n\nLa calidad de las {object:Semillas del Sueño} determina el tipo de recompensa.\n{item:208066}: Una transfiguración o materiales de fabricación.\n{item:208067}: Una mascota o materiales de fabricación.\n{item:208047}: Una montura o materiales de fabricación.'
+L['dreamseed_cache'] = 'Alijo de semillas del Sueño'
 
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = 'Muestra dónde están las {object:Tierra con Semillas del Sueño} para el logro {achievement:19013}.'

--- a/plugins/10_Dragonflight/localization/frFR.lua
+++ b/plugins/10_Dragonflight/localization/frFR.lua
@@ -894,11 +894,14 @@ L['plush_pillow_note'] = 'A l\'intérieur de la petite cabane, sur une table.'
 L['snuggle_buddy_note'] = 'A l\'intérieur d\'un petit bateau.'
 
 L['dreamseed_soil_label'] = 'Sol pour graine onirique'
-L['dreamseed_soil_note'] = [[
-Vous ne pouvez obtenir des {currency:2651}, {item:210651} et des cosmétiques que si vous contribuez ou plantez une Graine onirique, la quantité de {currency:2651} dépend de la qualité de la graine.
+L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+-- L['dreamseed_soil_note'] = [[
+-- Vous ne pouvez obtenir des {currency:2651}, {item:210651} et des cosmétiques que si vous contribuez ou plantez une Graine onirique, la quantité de {currency:2651} dépend de la qualité de la graine.
 
-Si vous contribuez avec des {currency:2650}, vous recevrez une petite quantité de matériaux d'artisanat et des {currency:2245s}.
-]]
+-- Si vous contribuez avec des {currency:2650}, vous recevrez une petite quantité de matériaux d'artisanat et des {currency:2245s}.
+-- ]]
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = 'Afficher les emplacements des {object:Sol pour graine onirique} pour le haut-fait {achievement:19013}.'
 

--- a/plugins/10_Dragonflight/localization/koKR.lua
+++ b/plugins/10_Dragonflight/localization/koKR.lua
@@ -833,6 +833,8 @@ L['snuggle_buddy_note'] = nil
 
 L['dreamseed_soil_label'] = nil
 L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = nil
 

--- a/plugins/10_Dragonflight/localization/ruRU.lua
+++ b/plugins/10_Dragonflight/localization/ruRU.lua
@@ -898,6 +898,8 @@ L['snuggle_buddy_note'] = nil
 
 L['dreamseed_soil_label'] = nil
 L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = nil
 

--- a/plugins/10_Dragonflight/localization/zhCN.lua
+++ b/plugins/10_Dragonflight/localization/zhCN.lua
@@ -865,7 +865,7 @@ L['envoy_of_winter_note'] = '收集{item:208881}，并在井附近使用{spell:4
 L['fruitface_note'] = '请求{dot:Pink}{npc:209950}对你施放{spell:421446}，以便让地上的{item:208837}显形。捡起果子使得{dot:Yellow}{npc:209980}现身。 攻击他，然后跟随他直至他跳入水中{dot:Red}并且召唤{npc:209966}和稀有{npc:209913}。'
 L['greedy_gessie_note'] = '为野餐收集{object:野生青菜}，{object:红玉之鳞甜瓜} 和{object:橙根}等原料，并将其放置在{npc:210285}们旁的篮子，以开启战斗。'
 L['nuoberon_note'] = '追逐乌龟{npc:209252}，拾取{object:美味的梦境大餐}对猴子{npc:209445}{spell:420253}，或与鳄鱼{npc:209456}搏斗，来帮助{npc:209101}做个有趣的梦！'
-L['reefbreaker_moruud_note'] = '收集附近全部6根{npc:210089}来攻击{npc:209898}。'
+L['reefbreaker_moruud_note'] = '利用附近全部6根{npc:210089}来牵制{npc:209898}。'
 L['surging_lasher_note'] = '当这片区域的{location:翡翠狂欢}事件激活时，会在此刷新。'
 
 L['in_a_tree'] = '在树上。'
@@ -896,17 +896,9 @@ L['plush_pillow_note'] = '小屋内的一张桌子上。'
 L['snuggle_buddy_note'] = '在一艘小船里。'
 
 L['dreamseed_soil_label'] = '梦境之种壤土'
-L['dreamseed_soil_note'] = [[
-    种植的梦境之种的品质，决定了幻梦奖赏的品质，可以开出相应数量的 {currency:2651}, 小宠物{item:210651}和"翡翠奖赏"配色幻化。
-{item:208066}结出{item:210217}
-{item:208067}结出{item:210218}
-{item:208047}结出{item:210219}
+L['dreamseed_soil_note'] = '{currency:2650} 的捐献进度, 决定了翡翠花蕾的品质。\n其品质影响{object:梦境之种宝箱}开出 {item:210059}的几率。\n{item:210224} (至少1次)\n{item:210225} (进度50%)\n{item:210226} (进度100%)\n\n梦境之种的品质决定了奖励的类型。\n{item:208066}: 专业材料 或 一件装饰品\n{item:208067}: 专业材料 或 一只宠物\n{item:208047}: 专业材料 或 一匹坐骑'
+L['dreamseed_cache'] = '梦境之种宝箱'
 
-    {currency:2650}的捐献进度, 决定了翡翠花蕾的品质，可以开出相应数量{currency:2245s}和专业材料。
-个人捐献1次(5个)，结算{item:210224}
-总进度达成50%，结算{item:210225}
-总进度达成100%，结算{item:210226}
-]]
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = '显示成就{achievement:19013}中{object:梦境之种壤土}的位置'
 
@@ -1009,9 +1001,9 @@ L['thorn_stag_note'] = '1. 杀死{npc:210976},对尸体使用{item:209866}。 �
 L['thorn_saber_note'] = '1. 杀死{npc:210975},对尸体使用{item:209867}。梦刃豹重生为{npc:210981}{npc:<荆生幽魂>}。\n\n2. 对其施放{spell:1515}。\n\n3. {npc:210981}有三种颜色(黑, 绿, 灰)。'
 L['thorn_bear_note'] = '1. 杀死{npc:210977},对尸体使用{item:209868}。鬃罴重生为{npc:210988}{npc:<荆生幽魂>}。\n\n2. 对其施放{spell:1515}。\n\n3. {npc:210988}有三种颜色(褐, 暗, 绿)。'
 
-L['nahqi_note'] = nil
+L['nahqi_note'] = '要对{npc:210908}施放{spell:1515}，需要{item:211314}。这来自于{item:210061}。\n\n{npc:210908}{npc:<愈合余烬>}围绕{location:阿梅达希尔}在高空{note:逆时针}绕圈缓慢飞翔，一圈下来耗时17:30。 \n它的刷新时间最少 30 分钟。 \n\n{note:这是只{npc:灵魂兽}。 只有兽王猎人能驯服。}'
 
-L['sulraka_note'] = nil
+L['sulraka_note'] = '{npc:210868}{npc:<吉布尔之女>}在{location:阿梅达希尔}东方以{note:逆时针}路线巡游， 大约17分钟绕一周。 \n它的刷新时间最少 30 分钟。\n\n当它行进时会在身后留下{object:笨重的踪迹}，持续3分钟。 \n由于一直潜行状态，你需要在一个刚刚刷新的{object:笨重的踪迹}前面使用{spell:1543}来让其显形。 \n先施放{spell:257284}和(或){spell:187650}，再尝试{spell:1515}。\n\n{note:注意：{npc:210868}即使受到攻击也不会停止前行，所以一定要使用陷阱或照明。否则{spell:1543}会在超距后取消施法。}\n\n{note:这是只{npc:灵魂兽}。 只有兽王猎人能驯服。}'
 
 -------------------------------------------------------------------------------
 ----------------------------- SECRETS OF AZEROTH ------------------------------

--- a/plugins/10_Dragonflight/localization/zhTW.lua
+++ b/plugins/10_Dragonflight/localization/zhTW.lua
@@ -897,6 +897,8 @@ L['snuggle_buddy_note'] = nil
 
 L['dreamseed_soil_label'] = nil
 L['dreamseed_soil_note'] = nil
+L['dreamseed_cache'] = nil
+
 L['options_icons_dream_of_seeds'] = '{achievement:19013}'
 L['options_icons_dream_of_seeds_desc'] = nil
 

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -111,6 +111,7 @@ map.nodes[51253128] = Rare({
 map.nodes[64178399] = Rare({
     id = 209898,
     quest = 77867,
+    vignette = {5806, 5814}, -- bug not display
     note = L['reefbreaker_moruud_note'],
     rlabel = ns.status.LightBlue('+50 ' .. L['rep']),
     rewards = {
@@ -145,6 +146,7 @@ map.nodes[29862077] = Rare({
     id = 209893,
     quest = 78015,
     vignette = 5835,
+    --rlabel = ns.status.LightBlue('+50 ' .. L['rep']), -- bug no rep now
     rewards = {
         Achievement({id = 19316, criteria = 62930}), -- Adventurer of the Emerald Dream
         Recipe({item = 210172, profession = 333}) -- Formula: Enchanted Wyrm's Dreaming Crest
@@ -335,7 +337,7 @@ local SurgingLasher = Class('SurgingLasher', Rare, {
     }
 }) -- Surging Lasher
 
-map.nodes[57015167] = SurgingLasher()
+map.nodes[57015167] = SurgingLasher({vignette = 5859}) --use Emerald Frenzy Vignette to hint rare's possile node
 map.nodes[58967188] = SurgingLasher()
 map.nodes[59896202] = SurgingLasher()
 
@@ -386,6 +388,36 @@ map.nodes[22743226] = Rare({
     }
 }) -- Balboan
 
+local Raszageth = Class('Raszageth', Rare, {
+    id = 209912,
+    quest = 77859,
+    vignette = 5808,
+    fgroup = 'raszageth',
+    -- note = L['raszageths_note'],
+    -- rlabel = ns.status.LightBlue('+50 ' .. L['rep']), -- NOT confirm yet
+    rewards = {
+        Item({item = 211303}) -- Dryad's Supply Pouch +25 rep -- Review
+    }
+}) -- Raszageth's Last Breath
+
+map.nodes[47081991] = Raszageth()
+map.nodes[63593476] = Raszageth()
+map.nodes[39965108] = Raszageth()
+
+local Amalgamation = Class('Amalgamation', Rare, {
+    id = 209915,
+    quest = 77856,
+    vignette = 5807, -- Coagulating Dreams
+    fgroup = 'amalgamation',
+    -- note = L['amalgamation_note'],
+    -- rlabel = ns.status.LightBlue('+50 ' .. L['rep']), -- NOT confirm yet
+    rewards = {
+        Item({item = 211303}) -- Dryad's Supply Pouch +25 rep -- Review
+    }
+}) -- Amalgamation of Dreams
+
+map.nodes[39615386] = Amalgamation()
+map.nodes[41202620] = Amalgamation() -- Review
 -------------------------------------------------------------------------------
 ---------------------------------- TREASURES ----------------------------------
 -------------------------------------------------------------------------------
@@ -844,12 +876,90 @@ local EmeraldBounty = Class('EmeraldBounty', Node, {
             return {
                 Achievement({id = 19013, criteria = self.criteriaID}), -- I Dream of Seeds
                 Achievement({id = 19198, criteria = {id = 1, qty = true}}), -- The Seeds I Sow
-                Currency({id = 2651, count = 20}), -- Seedbloom -- Spawned after the timer of the plant ran out, triggered hidden quest 77396 when looting
-                Transmog({item = 209990, slot = L['cosmetic']}), -- Overgrown Freyan Handguards
+                -- Currency({id = 2651, count = 20}), -- Seedbloom -- Spawned after the timer of the plant ran out, triggered hidden quest 77396 when looting
+                -- Spacer(),
+                Section(L['Dreamseed Cache']),
+                Mount({item = 210059, id = 1815}), -- Reins of the Winter Night Dreamsaber
+                DC.GrottoNetherwingDrake.HeadSpike, -- Gigantic Dreamseed by myself
+                DC.GrottoNetherwingDrake.OutcastPattern,
+                DC.GrottoNetherwingDrake.LongHorns,
+                DC.GrottoNetherwingDrake.ClusterSpikedBack,
+                Recipe({item = 211065, profession = 773}), -- Technique: Mark of the Auric Dreamstag -- Cache Drop
+                Recipe({item = 210490, profession = 773}), -- Technique: Vantus Rune: Amirdrassil, the Dream's Hope -- Cache Drop
+                Currency({id = 2652, type = 'requre progress 50%? +20'}), -- Dream Wardens Reputation -- REVIEW !!!
+                Currency({id = 2245, type = '+10'}), -- Flightstones
+                -- Currency({id = 2003}), -- Dragon Isles Supplies
+                Spacer(),
+                Section('{item:208066}'),
+                Item({item = 210217}),
+                Transmog({item = 209960, slot = L['cosmetic']}), -- Ceremonial Jacaranda Gown
+                Transmog({item = 209961, slot = L['cosmetic']}), -- Ceremonial Jacaranda Cape
+                Transmog({item = 209962, slot = L['cosmetic']}), -- Ceremonial Jacaranda Sandals
+                Transmog({item = 209963, slot = L['cosmetic']}), -- Ceremonial Jacaranda Gloves
+                Transmog({item = 209964, slot = L['cosmetic']}), -- Ceremonial Jacaranda Crown
+                Transmog({item = 209965, slot = L['cosmetic']}), -- Ceremonial Jacaranda Pantaloons
+                Transmog({item = 209966, slot = L['cosmetic']}), -- Ceremonial Jacaranda Branches
+                Transmog({item = 209967, slot = L['cosmetic']}), -- Ceremonial Jacaranda Belt
+                Transmog({item = 209968, slot = L['cosmetic']}), -- Ceremonial Jacaranda Wraps
+                Transmog({item = 210035, slot = L['cosmetic']}), -- Ceremonial Jacaranda Crook
+                Transmog({item = 210037, slot = L['cosmetic']}), -- Ceremonial Jacaranda Slab
+                Transmog({item = 210038, slot = L['cosmetic']}), -- Ceremonial Jacaranda Bloom
+                Transmog({item = 209969, slot = L['cosmetic']}), -- Vest of the Dreamfused Skull
+                Transmog({item = 209970, slot = L['cosmetic']}), -- Pelt of the Dreamfused Skull
                 Transmog({item = 209971, slot = L['cosmetic']}), -- Clogs of the Dreamfused Skull
-                Recipe({item = 210242, profession = 185}), -- Recipe: Slumbering Peacebloom Tea
-                DC.GrottoNetherwingDrake.HeadSpike, -- use Gigantic Dreamseed only
-                Pet({item = 210651, id = 4299}) -- Dustite
+                Transmog({item = 209972, slot = L['cosmetic']}), -- Grips of the Dreamfused Skull
+                Transmog({item = 209973, slot = L['cosmetic']}), -- Visage of the Dreamfused Skull
+                Transmog({item = 209974, slot = L['cosmetic']}), -- Leggings of the Dreamfused Skull
+                Transmog({item = 209975, slot = L['cosmetic']}), -- Pauldrons of the Dreamfused Skull
+                Transmog({item = 209976, slot = L['cosmetic']}), -- Buckle of the Dreamfused Skull
+                Transmog({item = 209977, slot = L['cosmetic']}), -- Bracers of the Dreamfused Skull
+                Transmog({item = 210030, slot = L['cosmetic']}), -- Bow of the Dreamfused Skull
+                Transmog({item = 210031, slot = L['cosmetic']}), -- Spike of the Dreamfused Skull
+                Transmog({item = 210033, slot = L['cosmetic']}), -- Essence of the Dreamfused Skull
+                Transmog({item = 209978, slot = L['cosmetic']}), -- Barkbloom Tunic
+                Transmog({item = 209979, slot = L['cosmetic']}), -- Barkbloom Cloak
+                Transmog({item = 209980, slot = L['cosmetic']}), -- Barkbloom Talons
+                Transmog({item = 209981, slot = L['cosmetic']}), -- Barkbloom Claws
+                Transmog({item = 209982, slot = L['cosmetic']}), -- Barkbloom Mask
+                Transmog({item = 209983, slot = L['cosmetic']}), -- Barkbloom Breeches
+                Transmog({item = 209984, slot = L['cosmetic']}), -- Barkbloom Shoulderpads
+                Transmog({item = 209985, slot = L['cosmetic']}), -- Barkbloom Sash
+                Transmog({item = 209986, slot = L['cosmetic']}), -- Barkbloom Wristguards
+                Transmog({item = 210036, slot = L['cosmetic']}), -- Barkbloom Saber
+                Transmog({item = 210039, slot = L['cosmetic']}), -- Barkbloom Warglaive
+                Transmog({item = 209987, slot = L['cosmetic']}), -- Overgrown Freyan Plate
+                Transmog({item = 209988, slot = L['cosmetic']}), -- Overgrown Freyan Drape
+                Transmog({item = 209989, slot = L['cosmetic']}), -- Overgrown Freyan Boots
+                Transmog({item = 209990, slot = L['cosmetic']}), -- Overgrown Freyan Handguards
+                Transmog({item = 209991, slot = L['cosmetic']}), -- Overgrown Freyan Helm
+                Transmog({item = 209992, slot = L['cosmetic']}), -- Overgrown Freyan Legguards
+                Transmog({item = 209993, slot = L['cosmetic']}), -- Overgrown Freyan Shoulderguards
+                Transmog({item = 209994, slot = L['cosmetic']}), -- Overgrown Freyan Girdle
+                Transmog({item = 209995, slot = L['cosmetic']}), -- Overgrown Freyan Vambraces
+                Transmog({item = 210029, slot = L['cosmetic']}), -- Overgrown Freyan Hatchet
+                Transmog({item = 210032, slot = L['cosmetic']}), -- Overgrown Freyan Smasher
+                Transmog({item = 210034, slot = L['cosmetic']}), -- Overgrown Freyan Pike
+                Spacer(),
+                Section('{item:208067}'),
+                Item({item = 210218}),
+                Recipe({item = 210242, profession = 185}), -- Recipe: Slumbering Peacebloom Tea -- Plump Dreamseed
+                Recipe({item = 210174, profession = 333}), -- Formula: Illusory Adornment: Dreams -- Plump Dreamseed
+                Recipe({item = 210241, profession = 171}), -- Recipe: Dreamwalker's Healing Potion -- Plump Dreamseed
+                Pet({item = 210690, id = 4306}), -- Elmer
+                Pet({item = 210689, id = 4305}), -- Snoots
+                Pet({item = 210571, id = 4296}), -- Snoozles
+                Pet({item = 210570, id = 4295}), -- Napps
+                Pet({item = 210651, id = 4299}), -- Dustite
+                Pet({item = 210648, id = 4298}), -- Seedle
+                Spacer(),
+                Section('{item:208047}'),
+                Item({item = 210219}),
+                Mount({item = 209950, id = 1810}), -- Reins of the Rekindled Dreamstag
+                Mount({item = 209947, id = 1808}), -- Reins of the Blossoming Dreamstag
+                Mount({item = 210775, id = 1835}), -- Reins of the Snowfluff Dreamtalon
+                Mount({item = 210769, id = 1833}), -- Reins of the Springtide Dreamtalon
+                Mount({item = 210057, id = 1817}), -- Reins of the Morning Flourish Dreamsaber
+                Mount({item = 210058, id = 1816}) -- Reins of the Evening Sun Dreamsaber
             }
         end
     }
@@ -923,7 +1033,7 @@ map.nodes[51555972] = Collectible({
     rewards = {
         Section(PVP_PROGRESS_REWARDS_HEADER .. ': 2300/8000'),
         Item({item = 211411}), -- Sprouting Dreamtrove
-        Currency({id = 2650}), -- Emerald Dewdrop
+        Currency({id = 2650, type = '+50'}), -- Emerald Dewdrop
         Spacer(), --
         Section(PVP_PROGRESS_REWARDS_HEADER .. ': 5600/8000'),
         Item({item = 211413}), -- Budding Dreamtrove
@@ -931,8 +1041,8 @@ map.nodes[51555972] = Collectible({
         Section(PVP_PROGRESS_REWARDS_HEADER .. ': 8000/8000'),
         Item({item = 211414}), -- Blossoming Dreamtrove
         Item({item = 208047}), -- Gigantic Dreamseed
-        Spacer(), Currency({id = 2245}), -- Flightstones
-        Currency({id = 2003}) -- Dragon Isles Supplies
+        Spacer(), Currency({id = 2245, type = '+10'}), -- Flightstones
+        Currency({id = 2003, type = '~35'}) -- Dragon Isles Supplies
     }
 })
 
@@ -1483,6 +1593,53 @@ local SeedbloomVendor = Class('SeedbloomVendor', NPC, {
         DG.Travel.AuroralDreamtalon:Count('1'), --
         DG.Guardian.SnowyUmbraclaw:Count('1'), --
         DruidSpacer(), --
+        Transmog({item = 209960, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Gown
+        Transmog({item = 209961, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Cape
+        Transmog({item = 209962, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Sandals
+        Transmog({item = 209963, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Gloves
+        Transmog({item = 209964, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Crown
+        Transmog({item = 209965, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Pantaloons
+        Transmog({item = 209966, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Branches
+        Transmog({item = 209967, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Belt
+        Transmog({item = 209968, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Wraps
+        Transmog({item = 210035, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Crook
+        Transmog({item = 210037, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Slab
+        Transmog({item = 210038, slot = L['cosmetic'], count = '1'}), -- Ceremonial Jacaranda Bloom
+        Transmog({item = 209969, slot = L['cosmetic'], count = '1'}), -- Vest of the Dreamfused Skull
+        Transmog({item = 209970, slot = L['cosmetic'], count = '1'}), -- Pelt of the Dreamfused Skull
+        Transmog({item = 209971, slot = L['cosmetic'], count = '1'}), -- Clogs of the Dreamfused Skull
+        Transmog({item = 209972, slot = L['cosmetic'], count = '1'}), -- Grips of the Dreamfused Skull
+        Transmog({item = 209973, slot = L['cosmetic'], count = '1'}), -- Visage of the Dreamfused Skull
+        Transmog({item = 209974, slot = L['cosmetic'], count = '1'}), -- Leggings of the Dreamfused Skull
+        Transmog({item = 209975, slot = L['cosmetic'], count = '1'}), -- Pauldrons of the Dreamfused Skull
+        Transmog({item = 209976, slot = L['cosmetic'], count = '1'}), -- Buckle of the Dreamfused Skull
+        Transmog({item = 209977, slot = L['cosmetic'], count = '1'}), -- Bracers of the Dreamfused Skull
+        Transmog({item = 210030, slot = L['cosmetic'], count = '1'}), -- Bow of the Dreamfused Skull
+        Transmog({item = 210031, slot = L['cosmetic'], count = '1'}), -- Spike of the Dreamfused Skull
+        Transmog({item = 210033, slot = L['cosmetic'], count = '1'}), -- Essence of the Dreamfused Skull
+        Transmog({item = 209978, slot = L['cosmetic'], count = '1'}), -- Barkbloom Tunic
+        Transmog({item = 209979, slot = L['cosmetic'], count = '1'}), -- Barkbloom Cloak
+        Transmog({item = 209980, slot = L['cosmetic'], count = '1'}), -- Barkbloom Talons
+        Transmog({item = 209981, slot = L['cosmetic'], count = '1'}), -- Barkbloom Claws
+        Transmog({item = 209982, slot = L['cosmetic'], count = '1'}), -- Barkbloom Mask
+        Transmog({item = 209983, slot = L['cosmetic'], count = '1'}), -- Barkbloom Breeches
+        Transmog({item = 209984, slot = L['cosmetic'], count = '1'}), -- Barkbloom Shoulderpads
+        Transmog({item = 209985, slot = L['cosmetic'], count = '1'}), -- Barkbloom Sash
+        Transmog({item = 209986, slot = L['cosmetic'], count = '1'}), -- Barkbloom Wristguards
+        Transmog({item = 210036, slot = L['cosmetic'], count = '1'}), -- Barkbloom Saber
+        Transmog({item = 210039, slot = L['cosmetic'], count = '1'}), -- Barkbloom Warglaive
+        Transmog({item = 209987, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Plate
+        Transmog({item = 209988, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Drape
+        Transmog({item = 209989, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Boots
+        Transmog({item = 209990, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Handguards
+        Transmog({item = 209991, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Helm
+        Transmog({item = 209992, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Legguards
+        Transmog({item = 209993, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Shoulderguards
+        Transmog({item = 209994, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Girdle
+        Transmog({item = 209995, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Vambraces
+        Transmog({item = 210029, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Hatchet
+        Transmog({item = 210032, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Smasher
+        Transmog({item = 210034, slot = L['cosmetic'], count = '1'}), -- Overgrown Freyan Pike
         Section(ns.requirement.Reputation(2574, 11, true):GetText()),
         Pet({item = 210690, id = 4306, count = '1'}), -- Elmer
         Pet({item = 210689, id = 4305, count = '1'}), -- Snoots

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -878,7 +878,7 @@ local EmeraldBounty = Class('EmeraldBounty', Node, {
                 Achievement({id = 19198, criteria = {id = 1, qty = true}}), -- The Seeds I Sow
                 -- Currency({id = 2651, count = 20}), -- Seedbloom -- Spawned after the timer of the plant ran out, triggered hidden quest 77396 when looting
                 -- Spacer(),
-                Section(L['Dreamseed Cache']),
+                Section(L['dreamseed_cache']),
                 Mount({item = 210059, id = 1815}), -- Reins of the Winter Night Dreamsaber
                 DC.GrottoNetherwingDrake.HeadSpike, -- Gigantic Dreamseed by myself
                 DC.GrottoNetherwingDrake.OutcastPattern,

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -146,7 +146,7 @@ map.nodes[29862077] = Rare({
     id = 209893,
     quest = 78015,
     vignette = 5835,
-    --rlabel = ns.status.LightBlue('+50 ' .. L['rep']), -- bug no rep now
+    -- rlabel = ns.status.LightBlue('+50 ' .. L['rep']), -- bug no rep now
     rewards = {
         Achievement({id = 19316, criteria = 62930}), -- Adventurer of the Emerald Dream
         Recipe({item = 210172, profession = 333}) -- Formula: Enchanted Wyrm's Dreaming Crest
@@ -337,7 +337,7 @@ local SurgingLasher = Class('SurgingLasher', Rare, {
     }
 }) -- Surging Lasher
 
-map.nodes[57015167] = SurgingLasher({vignette = 5859}) --use Emerald Frenzy Vignette to hint rare's possile node
+map.nodes[57015167] = SurgingLasher({vignette = 5859}) -- use Emerald Frenzy Vignette to hint rare's possile node
 map.nodes[58967188] = SurgingLasher()
 map.nodes[59896202] = SurgingLasher()
 
@@ -889,9 +889,7 @@ local EmeraldBounty = Class('EmeraldBounty', Node, {
                 Currency({id = 2652, type = 'requre progress 50%? +20'}), -- Dream Wardens Reputation -- REVIEW !!!
                 Currency({id = 2245, type = '+10'}), -- Flightstones
                 -- Currency({id = 2003}), -- Dragon Isles Supplies
-                Spacer(),
-                Section('{item:208066}'),
-                Item({item = 210217}),
+                Spacer(), Section('{item:208066}'), Item({item = 210217}),
                 Transmog({item = 209960, slot = L['cosmetic']}), -- Ceremonial Jacaranda Gown
                 Transmog({item = 209961, slot = L['cosmetic']}), -- Ceremonial Jacaranda Cape
                 Transmog({item = 209962, slot = L['cosmetic']}), -- Ceremonial Jacaranda Sandals
@@ -939,9 +937,7 @@ local EmeraldBounty = Class('EmeraldBounty', Node, {
                 Transmog({item = 210029, slot = L['cosmetic']}), -- Overgrown Freyan Hatchet
                 Transmog({item = 210032, slot = L['cosmetic']}), -- Overgrown Freyan Smasher
                 Transmog({item = 210034, slot = L['cosmetic']}), -- Overgrown Freyan Pike
-                Spacer(),
-                Section('{item:208067}'),
-                Item({item = 210218}),
+                Spacer(), Section('{item:208067}'), Item({item = 210218}),
                 Recipe({item = 210242, profession = 185}), -- Recipe: Slumbering Peacebloom Tea -- Plump Dreamseed
                 Recipe({item = 210174, profession = 333}), -- Formula: Illusory Adornment: Dreams -- Plump Dreamseed
                 Recipe({item = 210241, profession = 171}), -- Recipe: Dreamwalker's Healing Potion -- Plump Dreamseed
@@ -951,9 +947,7 @@ local EmeraldBounty = Class('EmeraldBounty', Node, {
                 Pet({item = 210570, id = 4295}), -- Napps
                 Pet({item = 210651, id = 4299}), -- Dustite
                 Pet({item = 210648, id = 4298}), -- Seedle
-                Spacer(),
-                Section('{item:208047}'),
-                Item({item = 210219}),
+                Spacer(), Section('{item:208047}'), Item({item = 210219}),
                 Mount({item = 209950, id = 1810}), -- Reins of the Rekindled Dreamstag
                 Mount({item = 209947, id = 1808}), -- Reins of the Blossoming Dreamstag
                 Mount({item = 210775, id = 1835}), -- Reins of the Snowfluff Dreamtalon


### PR DESCRIPTION
Please help review this
- Update Emerald Bounty Looting Table and Vendor List
- Update Emerald Bounty Note: L['dreamseed_soil_note'], L['dreamseed_cache']
- Update zhCN.lua
- Update 2 Rare Elites: "Amalgamation of Dreams", and "Raszageth's Last Breath" (may have more nodes, not knowing re-spawn mechanism )
