### PR TITLE
add 'War Supplies'

### DIFF
--- a/plugins/10_Dragonflight/common.lua
+++ b/plugins/10_Dragonflight/common.lua
@@ -257,6 +257,11 @@ ns.groups.ZSKERA_VAULTS = Group('zskera_vaults', 4909720, {
     type = ns.group_types.EXPANSION
 })
 
+ns.groups.WAR_SUPPLY = Group('war_supplies', 'star_chest_g', {
+    defaults = ns.GROUP_HIDDEN75,
+    type = ns.group_types.EXPANSION
+})
+
 -------------------------------------------------------------------------------
 
 ns.groups.ANCESTOR = Group('ancestor', 135946, {
@@ -1290,6 +1295,41 @@ local ElementalChest = Class('ElementalChest', ns.node.Treasure, {
 })
 
 ns.node.ElementalChest = ElementalChest
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CRATES ------------------------------
+-------------------------------------------------------------------------------
+
+local WarSupply = Class('WarSupply', Node, {
+    icon = 'star_chest_g',
+    scale = 1.5,
+    label = '{npc:135238}',
+    rlabel = ns.GetIconLink('war_mode_swords', 16),
+    quest = {72376, 72377}, -- first loot of the day rewards Conquest and extra Bloody Tokens
+    note = L['war_supply_chest_note'],
+    requires = ns.requirement.WarMode,
+    rewards = {
+        -- Achievement({id = 19294, criteria = {id = 1, qty = true}}), -- Tour of Duty: Emerald Dream
+        -- Achievement({id = 17851, criteria = {id = 1, qty = true}}), -- Tour of Duty: Zaralek Cavern
+        -- Achievement({id = 16592, criteria = {id = 1, qty = true}}), -- Tour of Duty: The Waking Shores
+        -- Achievement({id = 16594, criteria = {id = 1, qty = true}}), -- Tour of Duty: The Azure Span
+        -- Achievement({id = 16593, criteria = {id = 1, qty = true}}), -- Tour of Duty: Thaldraszus
+        -- Achievement({id = 16595, criteria = {id = 1, qty = true}}), -- Tour of Duty: Ohn'ahran Plains
+        -- Achievement({id = 16615, criteria = {id = 1, qty = true}}), -- Blood Bank
+        Achievement({id = 16613, criteria = {id = 1, qty = true}}), -- Finder's Keepers
+        Recipe({item = 201257, profession = 165}), -- Bloodstained Pattern: Infurious Hide
+        Recipe({item = 201259, profession = 165}), -- Bloodstained Pattern: Infurious Scales
+        Recipe({item = 201256, profession = 164}), -- Bloodstained Plans: Infurious Alloy
+        Recipe({item = 201258, profession = 197}), -- Bloodstained Pattern: Infurious Wildercloth Bolt
+        Item({item = 190451}), -- Rousing Ire
+        Currency({id = 2123, note = '+200'}), -- Bloody Tokens
+        Currency({id = 1602, note = '+60'}), -- Conquest
+        Currency({id = 1792, note = '+100'}) -- Honor
+    },
+    group = ns.groups.WAR_SUPPLY
+})
+
+ns.node.WarSupply = WarSupply
 
 -------------------------------------------------------------------------------
 ---------------------------------- INTERVALS ----------------------------------

--- a/plugins/10_Dragonflight/localization/deDE.lua
+++ b/plugins/10_Dragonflight/localization/deDE.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = 'Frostgebundene Kiste'
 L['options_icons_frostbound_chest'] = 'Frostgebundene Kiste'
 L['options_icons_frostbound_chest_desc'] = 'Zeigt die möglichen Positionen der {object:Frostgebundene Kisten} an.'
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = 'Angriff von Fyrakk'
 L['fyrakk_secured_shipment'] = 'Gesicherte Lieferung'
 

--- a/plugins/10_Dragonflight/localization/enUS.lua
+++ b/plugins/10_Dragonflight/localization/enUS.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = 'Frostbound Chest'
 L['options_icons_frostbound_chest'] = 'Frostbound Chest'
 L['options_icons_frostbound_chest_desc'] = 'Display possible locations of {object:Frostbound Chests}.'
 
+L['war_supply_chest_note'] = 'A {npc:135181} will fly overhead once every 45 minutes and drop a {npc:135238} at one of these potential drop locations.'
+L['options_icons_war_supplies_desc'] = 'Display {npc:135238} drop locations.'
+L['options_icons_war_supplies'] = '{npc:135238}'
+
 L['fyrakk_assault_label'] = 'Fyrakk Assault'
 L['fyrakk_secured_shipment'] = 'Secured Shipment'
 

--- a/plugins/10_Dragonflight/localization/esES.lua
+++ b/plugins/10_Dragonflight/localization/esES.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = 'Cofre Ligado a la Escarcha'
 L['options_icons_frostbound_chest'] = 'Cofre Ligado a la Escarcha'
 L['options_icons_frostbound_chest_desc'] = 'Muestra dónde pueden haber {object:Cofre Ligado a la Escarcha}.'
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = 'Asalto de Fyrakk'
 L['fyrakk_secured_shipment'] = 'Envío Seguro'
 

--- a/plugins/10_Dragonflight/localization/frFR.lua
+++ b/plugins/10_Dragonflight/localization/frFR.lua
@@ -145,6 +145,10 @@ L['frostbound_chest'] = 'Coffre lié par le givre'
 L['options_icons_frostbound_chest'] = 'Coffre lié par le givre'
 L['options_icons_frostbound_chest_desc'] = 'Afficher les emplacements possibles des {object:Coffres liés par le givre}.'
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = 'Assaut de Fyrakka'
 L['fyrakk_secured_shipment'] = 'Cargaison sécurisée'
 

--- a/plugins/10_Dragonflight/localization/koKR.lua
+++ b/plugins/10_Dragonflight/localization/koKR.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = '서리결속 보관함'
 L['options_icons_frostbound_chest'] = '서리결속 보관함'
 L['options_icons_frostbound_chest_desc'] = nil
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = nil
 L['fyrakk_secured_shipment'] = nil
 

--- a/plugins/10_Dragonflight/localization/ruRU.lua
+++ b/plugins/10_Dragonflight/localization/ruRU.lua
@@ -145,6 +145,10 @@ L['frostbound_chest'] = 'Скованный льдом сундук'
 L['options_icons_frostbound_chest'] = 'Скованный льдом сундук'
 L['options_icons_frostbound_chest_desc'] = 'Показать возможные места {object:Скованный льдом сундуков}.'
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = 'Налеты Фиракка'
 L['fyrakk_secured_shipment'] = 'Защищенные ресурсы'
 

--- a/plugins/10_Dragonflight/localization/zhCN.lua
+++ b/plugins/10_Dragonflight/localization/zhCN.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = '霜缚宝箱'
 L['options_icons_frostbound_chest'] = '霜缚宝箱'
 L['options_icons_frostbound_chest_desc'] = '显示 {object:霜缚宝箱} 可能的位置。'
 
+L['war_supply_chest_note'] = '一个 {npc:135181} 每隔45分钟就会在头顶飞过一次，并空投一个 {npc:135238} 到潜在可能的几个位置之一。'
+L['options_icons_war_supplies_desc'] = '显示 {npc:135238} 的空投位置。'
+L['options_icons_war_supplies'] = '{npc:135238}'
+
 L['fyrakk_assault_label'] = '菲莱克突袭'
 L['fyrakk_secured_shipment'] = '夺得的货物'
 

--- a/plugins/10_Dragonflight/localization/zhTW.lua
+++ b/plugins/10_Dragonflight/localization/zhTW.lua
@@ -144,6 +144,10 @@ L['frostbound_chest'] = '霜縛寶箱'
 L['options_icons_frostbound_chest'] = '霜縛寶箱'
 L['options_icons_frostbound_chest_desc'] = '顯示 {object:霜縛寶箱} 可能的位置.'
 
+L['war_supply_chest_note'] = nil
+L['options_icons_war_supplies_desc'] = nil
+L['options_icons_war_supplies'] = nil
+
 L['fyrakk_assault_label'] = '菲拉卡突襲'
 L['fyrakk_secured_shipment'] = '封住的貨箱'
 

--- a/plugins/10_Dragonflight/zones/azure_span.lua
+++ b/plugins/10_Dragonflight/zones/azure_span.lua
@@ -34,6 +34,7 @@ local Scoutpack = ns.node.Scoutpack
 local SignalTransmitter = ns.node.SignalTransmitter
 local Squirrel = ns.node.Squirrel
 local TuskarrTacklebox = ns.node.TuskarrTacklebox
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
@@ -1411,6 +1412,20 @@ map.nodes[67101270] = IcemawStorageCache()
 map.nodes[48406380] = ns.node.FrostboundChest()
 map.nodes[49706390] = ns.node.FrostboundChest()
 map.nodes[51306080] = ns.node.FrostboundChest()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[21403520] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[24505010] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[26202970] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[38303290] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[44904680] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[48505360] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[67701640] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[69705400] = WarSupply({fgroup = 'supply_azure_span'})
+map.nodes[71402890] = WarSupply({fgroup = 'supply_azure_span'})
 
 -------------------------------------------------------------------------------
 --------------------- TO ALL THE SQUIRRELS HIDDEN TIL NOW ---------------------

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -16,6 +16,8 @@ local Rare = ns.node.Rare
 local Treasure = ns.node.Treasure
 local Vendor = ns.node.Vendor
 
+local WarSupply = ns.node.WarSupply
+
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
 local Item = ns.reward.Item
@@ -1585,6 +1587,17 @@ map.nodes[63457357] = Somnut()
 map.nodes[65985217] = Somnut() -- On a Branch/Root
 map.nodes[66085014] = Somnut()
 map.nodes[66246327] = Somnut()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[32402360] = WarSupply({fgroup = 'supply_emerald_dream'})
+map.nodes[37705440] = WarSupply({fgroup = 'supply_emerald_dream'})
+map.nodes[39002520] = WarSupply({fgroup = 'supply_emerald_dream'})
+map.nodes[47202180] = WarSupply({fgroup = 'supply_emerald_dream'})
+map.nodes[52703340] = WarSupply({fgroup = 'supply_emerald_dream'})
+map.nodes[62206172] = WarSupply({fgroup = 'supply_emerald_dream'})
 
 -------------------------------------------------------------------------------
 ---------------------------- EMERALD DREAM SAFARI -----------------------------

--- a/plugins/10_Dragonflight/zones/forbidden_reach2.lua
+++ b/plugins/10_Dragonflight/zones/forbidden_reach2.lua
@@ -17,6 +17,7 @@ local Dragonglyph = ns.node.Dragonglyph
 local ElusiveCreature = ns.node.ElusiveCreature
 local Flag = ns.node.Flag
 local SignalTransmitter = ns.node.SignalTransmitter
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
@@ -624,6 +625,18 @@ map.nodes[48947352] = ns.node.ElementalChest({
         Item({item = 204577}) -- Condensed Nature Magic
     }
 }) -- Storm-Bound Chest
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[15001480] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[31405380] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[40801240] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[41203670] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[50104390] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[59003900] = WarSupply({fgroup = 'supply_forbidden_reach'})
+map.nodes[70707710] = WarSupply({fgroup = 'supply_forbidden_reach'})
 
 -------------------------------------------------------------------------------
 --------------------------------- BATTLE PETS ---------------------------------

--- a/plugins/10_Dragonflight/zones/ohnahran_plains.lua
+++ b/plugins/10_Dragonflight/zones/ohnahran_plains.lua
@@ -31,6 +31,7 @@ local Scoutpack = ns.node.Scoutpack
 local SignalTransmitter = ns.node.SignalTransmitter
 local Squirrel = ns.node.Squirrel
 local TuskarrTacklebox = ns.node.TuskarrTacklebox
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
@@ -946,6 +947,20 @@ map.nodes[62005160] = LightningBoundChest()
 map.nodes[65601340] = LightningBoundChest()
 map.nodes[67001180] = LightningBoundChest()
 map.nodes[67101270] = LightningBoundChest()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[22406370] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[36003220] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[35926292] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[48512646] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[61156158] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[62908070] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[75094969] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[77702440] = WarSupply({fgroup = 'supply_ohnahran_plains'})
+map.nodes[80907569] = WarSupply({fgroup = 'supply_ohnahran_plains'})
 
 -------------------------------------------------------------------------------
 --------------------------------- BATTLE PETS ---------------------------------

--- a/plugins/10_Dragonflight/zones/thaldraszus.lua
+++ b/plugins/10_Dragonflight/zones/thaldraszus.lua
@@ -33,6 +33,7 @@ local Scoutpack = ns.node.Scoutpack
 local SignalTransmitter = ns.node.SignalTransmitter
 local Squirrel = ns.node.Squirrel
 local TuskarrTacklebox = ns.node.TuskarrTacklebox
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Appearance = ns.reward.Appearance
@@ -57,10 +58,6 @@ local DC = ns.DRAGON_CUSTOMIZATIONS
 local map = Map({id = 2025, settings = true})
 local val = Map({id = 2112, settings = false}) -- Valdrakken
 local tpf = Map({id = 2085, settings = false}) -- The Primalist Future
-
--------------------------------------------------------------------------------
-
--- war supplies 41974893
 
 -------------------------------------------------------------------------------
 ------------------------------------ RARES ------------------------------------
@@ -865,6 +862,21 @@ map.nodes[61906180] = TitanChest()
 map.nodes[54006140] = ns.node.FrostboundChest()
 map.nodes[55206290] = ns.node.FrostboundChest()
 map.nodes[56206450] = ns.node.FrostboundChest()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[37337483] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[41974893] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[43806980] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[49405770] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[50105870] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[53903600] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[57385384] = WarSupply({fgroup = 'supply_thaldraszus'}) -- bug: dispear on openning
+map.nodes[59606171] = WarSupply({fgroup = 'supply_thaldraszus'}) -- bug: dispear on openning
+map.nodes[61903070] = WarSupply({fgroup = 'supply_thaldraszus'})
+map.nodes[64605970] = WarSupply({fgroup = 'supply_thaldraszus'})
 
 -------------------------------------------------------------------------------
 --------------------------------- BATTLE PETS ---------------------------------

--- a/plugins/10_Dragonflight/zones/waking_shores.lua
+++ b/plugins/10_Dragonflight/zones/waking_shores.lua
@@ -32,6 +32,7 @@ local Scoutpack = ns.node.Scoutpack
 local SignalTransmitter = ns.node.SignalTransmitter
 local Squirrel = ns.node.Squirrel
 local TuskarrTacklebox = ns.node.TuskarrTacklebox
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
@@ -996,6 +997,20 @@ map.nodes[57604350] = ns.node.DracthyrSupplyChest()
 map.nodes[66405660] = ns.node.DracthyrSupplyChest()
 map.nodes[67905800] = ns.node.DracthyrSupplyChest()
 map.nodes[68005890] = ns.node.DracthyrSupplyChest()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[24227983] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[32006370] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[32605100] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[47997652] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[51545639] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[51794273] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[66123326] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[70866535] = WarSupply({fgroup = 'supply_waking_shore'})
+map.nodes[78704910] = WarSupply({fgroup = 'supply_waking_shore'})
 
 -------------------------------------------------------------------------------
 --------------------------------- BATTLE PETS ---------------------------------

--- a/plugins/10_Dragonflight/zones/zaralek_cavern.lua
+++ b/plugins/10_Dragonflight/zones/zaralek_cavern.lua
@@ -16,6 +16,7 @@ local AncientStone = ns.node.AncientStone
 local Dragonglyph = ns.node.Dragonglyph
 local PT = ns.node.ProfessionTreasures
 local ElusiveCreature = ns.node.ElusiveCreature
+local WarSupply = ns.node.WarSupply
 
 local Achievement = ns.reward.Achievement
 local Currency = ns.reward.Currency
@@ -745,6 +746,18 @@ map.nodes[60006300] = SmellyTreasureChest()
 map.nodes[62504200] = SmellyTreasureChest()
 map.nodes[62906990] = SmellyTreasureChest()
 map.nodes[65205530] = SmellyTreasureChest()
+
+-------------------------------------------------------------------------------
+------------------------------ WAR SUPPLY CHESTS ------------------------------
+-------------------------------------------------------------------------------
+
+map.nodes[41903760] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[44502840] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[46205880] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[47104430] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[48501800] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[53904130] = WarSupply({fgroup = 'supply_zaralek_cavern'})
+map.nodes[57906610] = WarSupply({fgroup = 'supply_zaralek_cavern'})
 
 -------------------------------------------------------------------------------
 --------------------------------- BATTLE PETS ---------------------------------


### PR DESCRIPTION
War Supplies in Tyrhold seem have a bug: Dispearing on openning.
In Ohnahran Plains when a War Supply respawns, vignette of the airplane do not display on map.