### PR TITLE
Korthia's Archive Relics are treated as account-wide, should be per-character

### DIFF
--- a/plugins/09_Shadowlands/zones/korthia.lua
+++ b/plugins/09_Shadowlands/zones/korthia.lua
@@ -468,6 +468,8 @@ local Relic = Class('Relic', ns.node.Treasure, {
     end
 })
 
+Relic.IsCollected = function() return false end
+
 -------------------------------------------------------------------------------
 
 -- GHO: 40914788


### PR DESCRIPTION
Korthia's Relics are obtained by non-repeatable one-time quest. They provide good research reward and relics appear per-character visually in archive itself. IMO because of this they should be tracked per-character.

Right now they are removed for every character from map when "remove collected" option is turned on as soon as you obtain relic on any of characters, because parent class (`Treasure`)'s `:IsCollected` reports `true` as relics have account-wide achievement listed as "reward". I assume it worked before when this achievement wasn't account-wide.

This simple fix gives `Relic` class its own `:IsCollected` that always returns `false`, making HN logic to remove pin when node `:IsCompleted` instead.