### PR TITLE
Move Profession Treasures to \core

### DIFF
--- a/core/groups.lua
+++ b/core/groups.lua
@@ -136,12 +136,14 @@ ns.groups = {
         type = ns.group_types.STANDARD,
         order = 2
     }),
-    PETBATTLE = Group('pet_battles', 'paw_y',
+    PROFESSION_TREASURES = Group('profession_treasures', 4620676,
         {type = ns.group_types.STANDARD, order = 3}),
-    QUEST = Group('quests', 'quest_ay',
+    PETBATTLE = Group('pet_battles', 'paw_y',
         {type = ns.group_types.STANDARD, order = 4}),
-    VENDOR = Group('vendors', 'bag', {type = ns.group_types.STANDARD, order = 5}),
-    MISC = Group('misc', 454046, {type = ns.group_types.STANDARD, order = 6}),
+    QUEST = Group('quests', 'quest_ay',
+        {type = ns.group_types.STANDARD, order = 5}),
+    VENDOR = Group('vendors', 'bag', {type = ns.group_types.STANDARD, order = 6}),
+    MISC = Group('misc', 454046, {type = ns.group_types.STANDARD, order = 7}),
     ---------------------------------------------------------------------------
     SKYRIDING_RACE = Group('skyriding_race', 1100022, {
         defaults = ns.GROUP_HIDDEN,

--- a/core/nodes.lua
+++ b/core/nodes.lua
@@ -503,6 +503,54 @@ local PetBattle = Class('PetBattle', NPC, {
 })
 
 -------------------------------------------------------------------------------
+----------------------------- PROFESSION TREASURES ----------------------------
+-------------------------------------------------------------------------------
+
+local ProfessionMaster = Class('ProfessionMaster', NPC, {
+    scale = 0.9,
+    group = ns.groups.PROFESSION_TREASURES
+})
+
+function ProfessionMaster:IsEnabled()
+    if not ns.PlayerHasProfession(self.skillID) then return false end
+    return NPC.IsEnabled(self)
+end
+
+local ProfessionTreasure = Class('ProfessionTreasure', Item, {
+    scale = 0.9,
+    group = ns.groups.PROFESSION_TREASURES
+})
+
+function ProfessionTreasure:IsEnabled()
+    if not ns.PlayerHasProfession(self.skillID) then return false end
+    return Item.IsEnabled(self)
+end
+
+local PM = {}
+local PT = {}
+
+for _, profession in pairs(ns.professions) do
+    if profession.variantID ~= nil then
+        local name = profession.name
+        local icon = profession.icon
+        local skillID = profession.skillID
+        local variantID = profession.variantID[10]
+
+        PM[name] = Class(name .. 'Master', ProfessionMaster, {
+            icon = icon,
+            skillID = skillID,
+            requires = ns.requirement.Profession(skillID, variantID, 25)
+        })
+
+        PT[name] = Class(name .. 'Treasure', ProfessionTreasure, {
+            icon = icon,
+            skillID = skillID,
+            requires = ns.requirement.Profession(skillID, variantID, 25)
+        })
+    end
+end
+
+-------------------------------------------------------------------------------
 ------------------------------------ QUEST ------------------------------------
 -------------------------------------------------------------------------------
 
@@ -731,6 +779,8 @@ ns.node = {
     Node = Node,
     NPC = NPC,
     PetBattle = PetBattle,
+    ProfessionMasters = PM,
+    ProfessionTreasures = PT,
     Quest = Quest,
     Rare = Rare,
     Treasure = Treasure,

--- a/core/nodes.lua
+++ b/core/nodes.lua
@@ -534,7 +534,7 @@ for _, profession in pairs(ns.professions) do
         local name = profession.name
         local icon = profession.icon
         local skillID = profession.skillID
-        local variantID = profession.variantID[10]
+        local variantID = profession.variantID[ns.expansion]
 
         PM[name] = Class(name .. 'Master', ProfessionMaster, {
             icon = icon,

--- a/core/nodes.lua
+++ b/core/nodes.lua
@@ -534,18 +534,33 @@ for _, profession in pairs(ns.professions) do
         local name = profession.name
         local icon = profession.icon
         local skillID = profession.skillID
-        local variantID = profession.variantID[ns.expansion]
 
         PM[name] = Class(name .. 'Master', ProfessionMaster, {
             icon = icon,
             skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 25)
+            level = 1,
+            getters = {
+                requires = function(self)
+                    local profession = ns.getProfessionBySkillID(self.skillID)
+                    local variantID = profession.variantID[ns.expansion]
+                    local level = self.level
+                    return ns.requirement.Profession(skillID, variantID, level)
+                end
+            }
         })
 
         PT[name] = Class(name .. 'Treasure', ProfessionTreasure, {
             icon = icon,
             skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 25)
+            level = 1,
+            getters = {
+                requires = function(self)
+                    local profession = ns.getProfessionBySkillID(self.skillID)
+                    local variantID = profession.variantID[ns.expansion]
+                    local level = self.level
+                    return ns.requirement.Profession(skillID, variantID, level)
+                end
+            }
         })
     end
 end

--- a/core/professions.lua
+++ b/core/professions.lua
@@ -97,6 +97,10 @@ ns.professions = {
 
 -------------------------------------------------------------------------------
 
+ns.professionsBySkillID = {}
+
+-------------------------------------------------------------------------------
+
 local function GetName(self)
     return C_TradeSkillUI.GetTradeSkillDisplayName(self.skillID)
 end
@@ -106,4 +110,15 @@ local function HasProfession(self) return ns.PlayerHasProfession(self.skillID) e
 for name, profession in pairs(ns.professions) do
     profession.GetName = GetName
     profession.HasProfession = HasProfession
+
+    -- add reverse lookup
+    ns.professionsBySkillID[profession.skillID] = profession
 end
+
+-------------------------------------------------------------------------------
+
+local function getProfessionBySkillID(skillID)
+    return ns.professionsBySkillID[skillID]
+end
+
+ns.getProfessionBySkillID = getProfessionBySkillID

--- a/plugins/10_Dragonflight/common.lua
+++ b/plugins/10_Dragonflight/common.lua
@@ -133,11 +133,6 @@ ns.groups.PROFESSION_RARES = Group('profession_rares', 'peg_rd', {
     type = ns.group_types.EXPANSION
 })
 
-ns.groups.PROFESSION_TREASURES = Group('profession_treasures', 4620676, {
-    defaults = ns.GROUP_HIDDEN,
-    type = ns.group_types.EXPANSION
-})
-
 ns.groups.REED_CHEST = Group('reed_chest', 'chest_yw', {
     defaults = ns.GROUP_HIDDEN,
     type = ns.group_types.EXPANSION
@@ -474,57 +469,6 @@ local RareElite = Class('RareElite', Rare, {
 })
 
 ns.node.RareElite = RareElite
-
--------------------------------------------------------------------------------
------------------------------ PROFESSION TREASURES ----------------------------
--------------------------------------------------------------------------------
-
-local ProfessionMaster = Class('ProfessionMaster', ns.node.NPC, {
-    scale = 0.9,
-    group = ns.groups.PROFESSION_TREASURES
-})
-
-function ProfessionMaster:IsEnabled()
-    if not ns.PlayerHasProfession(self.skillID) then return false end
-    return ns.node.NPC.IsEnabled(self)
-end
-
-local ProfessionTreasure = Class('ProfessionTreasure', ns.node.Item, {
-    scale = 0.9,
-    group = ns.groups.PROFESSION_TREASURES
-})
-
-function ProfessionTreasure:IsEnabled()
-    if not ns.PlayerHasProfession(self.skillID) then return false end
-    return ns.node.Item.IsEnabled(self)
-end
-
-ns.node.ProfessionMasters = {}
-ns.node.ProfessionTreasures = {}
-
-local PM = ns.node.ProfessionMasters
-local PT = ns.node.ProfessionTreasures
-
-for _, profession in pairs(ns.professions) do
-    if profession.variantID ~= nil then
-        local name = profession.name
-        local icon = profession.icon
-        local skillID = profession.skillID
-        local variantID = profession.variantID[10]
-
-        PM[name] = Class(name .. 'Master', ProfessionMaster, {
-            icon = icon,
-            skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 25)
-        })
-
-        PT[name] = Class(name .. 'Treasure', ProfessionTreasure, {
-            icon = icon,
-            skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 25)
-        })
-    end
-end
 
 -------------------------------------------------------------------------------
 -------------------------------- DRAGON GLYPHS --------------------------------

--- a/plugins/10_Dragonflight/zones/azure_span.lua
+++ b/plugins/10_Dragonflight/zones/azure_span.lua
@@ -901,54 +901,63 @@ map.nodes[19522460] = PetBattle({
 map.nodes[12504940] = PT.Leatherworking({
     id = 201018,
     quest = 70269,
+    level = 25,
     note = L['pt_leath_well_danced_drum_note']
 }) -- Well-Danced Drum
 
 map.nodes[16203880] = PT.Tailoring({
     id = 198680,
     quest = 70284,
+    level = 25,
     note = L['pt_tailor_decaying_brackenhide_blanket_note']
 }) -- Decaying Brackenhide Blanket
 
 map.nodes[16303849] = PT.Alchemy({
     id = 198599,
     quest = 70208,
+    level = 25,
     note = L['pt_alch_experimental_decay_sample_note']
 }) -- Experimental Decay Sample
 
 map.nodes[16703880] = PT.Leatherworking({
     id = 198658,
     quest = 70266,
+    level = 25,
     note = L['pt_leath_decay_infused_tanning_oil_note']
 }) -- Decay-Infused Tanning Oil
 
 map.nodes[21564555] = PT.Enchanting({
     id = 198694,
     quest = 70298,
+    level = 25,
     note = L['pt_ench_enriched_earthen_shard_note']
 }) -- Enriched Earthen Shard
 
 map.nodes[38505920] = PT.Enchanting({
     id = 198799,
     quest = 70336,
+    level = 25,
     note = L['pt_ench_forgotten_arcane_tome_note']
 }) -- Forgotten Arcane Tome
 
 map.nodes[40705450] = PT.Tailoring({
     id = 198662,
     quest = 70267,
+    level = 25,
     note = L['pt_tailor_intriguing_bolt_of_blue_cloth_note']
 }) -- Intriguing Bolt of Blue Cloth
 
 map.nodes[43703090] = PT.Inscription({
     id = 198686,
     quest = 70293,
+    level = 25,
     note = L['pt_script_frosted_parchment_note']
 }) -- Frosted Parchment
 
 map.nodes[44606120] = PT.Jewelcrafting({
     id = 201016,
     quest = 70271,
+    level = 25,
     note = L['pt_jewel_harmonic_crystal_harmonizer_note'],
     pois = {POI({44726215, 44176203, 44686017})}
 }) -- Harmonic Crystal Harmonizer
@@ -956,24 +965,28 @@ map.nodes[44606120] = PT.Jewelcrafting({
 map.nodes[45006130] = PT.Jewelcrafting({
     id = 198664,
     quest = 70277,
+    level = 25,
     note = L['pt_jewel_crystalline_overgrowth_note']
 }) -- Crystalline Overgrowth
 
 map.nodes[45106120] = PT.Enchanting({
     id = 201013,
     quest = 70290,
+    level = 25,
     note = L['pt_ench_faintly_enchanted_remains_note']
 }) -- Faintly Enchanted Remains
 
 map.nodes[46202390] = PT.Inscription({
     id = 198693,
     quest = 70297,
+    level = 25,
     note = L['pt_script_dusty_darkmoon_card_note']
 }) -- Dusty Darkmoon Card
 
 map.nodes[53146614] = PT.Blacksmithing({
     id = 201011,
     quest = 70314,
+    level = 25,
     note = L['pt_smith_spelltouched_tongs_note'],
     requires = {
         ns.requirement.Profession(186), ns.requirement.Profession(164, 2822, 25)
@@ -984,12 +997,14 @@ map.nodes[53146614] = PT.Blacksmithing({
 map.nodes[57504130] = PT.Leatherworking({
     id = 198683,
     quest = 70286,
+    level = 25,
     note = L['pt_leath_treated_hides_note']
 }) -- Treated Hides
 
 map.nodes[67061316] = PT.Alchemy({
     id = 198712,
     quest = 70309,
+    level = 25,
     note = L['pt_alch_firewater_powder_sample_note']
 }) -- Firewater Powder Sample
 
@@ -998,6 +1013,7 @@ map.nodes[67061316] = PT.Alchemy({
 map.nodes[17762167] = PM.Engineering({
     id = 194838,
     quest = 70252,
+    level = 25,
     note = L['pm_engi_frizz_buzzcrank'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1008,6 +1024,7 @@ map.nodes[17762167] = PM.Engineering({
 map.nodes[40146434] = PM.Inscription({
     id = 194840,
     quest = 70254,
+    level = 25,
     note = L['pm_script_lydiara_whisperfeather'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1018,6 +1035,7 @@ map.nodes[40146434] = PM.Inscription({
 map.nodes[46244076] = PM.Jewelcrafting({
     id = 194841,
     quest = 70255,
+    level = 25,
     note = L['pm_jewel_pluutar'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -734,11 +734,7 @@ map.nodes[63507151] = PT.Inscription({
 
 map.nodes[36044664] = PT.Inscription({id = 210460, quest = 78413, level = 25}) -- Primalist Shadowbinding Rune
 
-map.nodes[37262292] = PT.Blacksmithing({
-    id = 210466,
-    quest = 78419,
-    level = 25
-}) -- Flamesworn Render
+map.nodes[37262292] = PT.Blacksmithing({id = 210466, quest = 78419, level = 25}) -- Flamesworn Render
 
 map.nodes[49836299] = PT.Blacksmithing({
     id = 210464,
@@ -747,11 +743,7 @@ map.nodes[49836299] = PT.Blacksmithing({
     note = L['amirdrassil_defenders_shield_note']
 }) -- Amirdrassil Defender's Shield
 
-map.nodes[36344680] = PT.Blacksmithing({
-    id = 210465,
-    quest = 78418,
-    level = 25
-}) -- Deathstalker Chasis
+map.nodes[36344680] = PT.Blacksmithing({id = 210465, quest = 78418, level = 25}) -- Deathstalker Chasis
 
 map.nodes[39575227] = PT.Engineering({
     id = 210193,
@@ -805,17 +797,10 @@ map.nodes[43513336] = PT.Jewelcrafting({
     note = L['handful_of_pebbles_note']
 }) -- Handful of Pebbles
 
-map.nodes[58945389] = PT.Jewelcrafting({
-    id = 210202,
-    quest = 78285,
-    level = 25
-}) -- Coalesced Dreamstone
+map.nodes[58945389] = PT.Jewelcrafting({id = 210202, quest = 78285, level = 25}) -- Coalesced Dreamstone
 
-map.nodes[41766650] = PT.Leatherworking({
-    id = 210208,
-    quest = 78298,
-    level = 25
-}) -- Tuft of Dreamsaber Fur
+map.nodes[41766650] =
+    PT.Leatherworking({id = 210208, quest = 78298, level = 25}) -- Tuft of Dreamsaber Fur
 
 map.nodes[37467101] = PT.Leatherworking({
     id = 210211,

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -734,7 +734,11 @@ map.nodes[63507151] = PT.Inscription({
 
 map.nodes[36044664] = PT.Inscription({id = 210460, quest = 78413, level = 25}) -- Primalist Shadowbinding Rune
 
-map.nodes[37262292] = PT.Blacksmithing({id = 210466, quest = 78419, level = 25}) -- Flamesworn Render
+map.nodes[37262292] = PT.Blacksmithing({
+    id = 210466,
+    quest = 78419,
+    level = 25
+}) -- Flamesworn Render
 
 map.nodes[49836299] = PT.Blacksmithing({
     id = 210464,
@@ -743,7 +747,11 @@ map.nodes[49836299] = PT.Blacksmithing({
     note = L['amirdrassil_defenders_shield_note']
 }) -- Amirdrassil Defender's Shield
 
-map.nodes[36344680] = PT.Blacksmithing({id = 210465, quest = 78418, level = 25}) -- Deathstalker Chasis
+map.nodes[36344680] = PT.Blacksmithing({
+    id = 210465,
+    quest = 78418,
+    level = 25
+}) -- Deathstalker Chasis
 
 map.nodes[39575227] = PT.Engineering({
     id = 210193,
@@ -797,9 +805,17 @@ map.nodes[43513336] = PT.Jewelcrafting({
     note = L['handful_of_pebbles_note']
 }) -- Handful of Pebbles
 
-map.nodes[58945389] = PT.Jewelcrafting({id = 210202, quest = 78285, level = 25}) -- Coalesced Dreamstone
+map.nodes[58945389] = PT.Jewelcrafting({
+    id = 210202,
+    quest = 78285,
+    level = 25
+}) -- Coalesced Dreamstone
 
-map.nodes[41766650] = PT.Leatherworking({id = 210208, quest = 78298, level = 25}) -- Tuft of Dreamsaber Fur
+map.nodes[41766650] = PT.Leatherworking({
+    id = 210208,
+    quest = 78298,
+    level = 25
+}) -- Tuft of Dreamsaber Fur
 
 map.nodes[37467101] = PT.Leatherworking({
     id = 210211,

--- a/plugins/10_Dragonflight/zones/emerald_dream.lua
+++ b/plugins/10_Dragonflight/zones/emerald_dream.lua
@@ -697,11 +697,12 @@ map.nodes[69575284] = UnwakingEcho({
 -------------------------------------------------------------------------------
 -- https://www.wowhead.com/ptr-2/items/quality:4?filter=168:99:82;2:11:2;0:0:100200
 
-map.nodes[54043264] = PT.Alchemy({id = 210184, quest = 78264}) -- Half-Filled Dreamless Sleep Potion
+map.nodes[54043264] = PT.Alchemy({id = 210184, quest = 78264, level = 25}) -- Half-Filled Dreamless Sleep Potion
 
 bor.nodes[50934991] = PT.Alchemy({
     id = 210185,
     quest = 78269,
+    level = 25,
     parent = {
         id = map.id,
         note = L['in_cave'],
@@ -709,96 +710,108 @@ bor.nodes[50934991] = PT.Alchemy({
     }
 }) -- Splash Potion of Narcolepsy
 
-map.nodes[36264653] = PT.Alchemy({id = 210190, quest = 78275}) -- Blazeroot
+map.nodes[36264653] = PT.Alchemy({id = 210190, quest = 78275, level = 25}) -- Blazeroot
 
-map.nodes[46152058] = PT.Enchanting({id = 210231, quest = 78309}) -- Everburning Core
+map.nodes[46152058] = PT.Enchanting({id = 210231, quest = 78309, level = 25}) -- Everburning Core
 
-map.nodes[38373020] = PT.Enchanting({id = 210228, quest = 78308}) -- Pure Dream Water
+map.nodes[38373020] = PT.Enchanting({id = 210228, quest = 78308, level = 25}) -- Pure Dream Water
 
 map.nodes[66367419] = PT.Enchanting({
     id = 210234,
     quest = 78310,
+    level = 25,
     note = L['essence_of_dreams_note']
 }) -- Essence of Dreams
 
-map.nodes[55642751] = PT.Inscription({id = 210458, quest = 78411}) -- Winnie's Notes on Flora and Fauna
+map.nodes[55642751] = PT.Inscription({id = 210458, quest = 78411, level = 25}) -- Winnie's Notes on Flora and Fauna
 
 map.nodes[63507151] = PT.Inscription({
     id = 210459,
     quest = 78412,
+    level = 25,
     note = L['grove_keepers_pillar_note']
 }) -- Grove Keeper's Pillar
 
-map.nodes[36044664] = PT.Inscription({id = 210460, quest = 78413}) -- Primalist Shadowbinding Rune
+map.nodes[36044664] = PT.Inscription({id = 210460, quest = 78413, level = 25}) -- Primalist Shadowbinding Rune
 
-map.nodes[37262292] = PT.Blacksmithing({id = 210466, quest = 78419}) -- Flamesworn Render
+map.nodes[37262292] = PT.Blacksmithing({id = 210466, quest = 78419, level = 25}) -- Flamesworn Render
 
 map.nodes[49836299] = PT.Blacksmithing({
     id = 210464,
     quest = 78417,
+    level = 25,
     note = L['amirdrassil_defenders_shield_note']
 }) -- Amirdrassil Defender's Shield
 
-map.nodes[36344680] = PT.Blacksmithing({id = 210465, quest = 78418}) -- Deathstalker Chasis
+map.nodes[36344680] = PT.Blacksmithing({id = 210465, quest = 78418, level = 25}) -- Deathstalker Chasis
 
 map.nodes[39575227] = PT.Engineering({
     id = 210193,
     quest = 78278,
+    level = 25,
     note = L['experimental_dreamcatcher_note']
 }) -- Experimental Dreamcatcher
 
 bor.nodes[49486918] = PT.Engineering({
     id = 210194,
     quest = 78279,
+    level = 25,
     location = L['in_cave'],
     parent = map.id
 }) -- Insomniotron
 
-map.nodes[62683626] = PT.Engineering({id = 210197, quest = 78281}) -- Unhatched Battery
+map.nodes[62683626] = PT.Engineering({id = 210197, quest = 78281, level = 25}) -- Unhatched Battery
 
 map.nodes[53272791] = PT.Tailoring({
     id = 210461,
     quest = 78414,
+    level = 25,
     note = L['exceedingly_soft_wildercloth_note']
 }) -- Exceedingly Soft Wildercloth
 
 map.nodes[49826149] = PT.Tailoring({
     id = 210462,
     quest = 78415,
+    level = 25,
     note = L['plush_pillow_note']
 }) -- Plush Pillow
 
 map.nodes[40708615] = PT.Tailoring({
     id = 210463,
     quest = 78416,
+    level = 25,
     note = L['snuggle_buddy_note']
 }) -- Snuggle Buddy
 
 map.nodes[33204656] = PT.Jewelcrafting({
     id = 210200,
     quest = 78282,
+    level = 25,
     note = L['petrified_hope_note']
 }) -- Petrified Hope
 
 map.nodes[43513336] = PT.Jewelcrafting({
     id = 210201,
     quest = 78283,
+    level = 25,
     note = L['handful_of_pebbles_note']
 }) -- Handful of Pebbles
 
-map.nodes[58945389] = PT.Jewelcrafting({id = 210202, quest = 78285}) -- Coalesced Dreamstone
+map.nodes[58945389] = PT.Jewelcrafting({id = 210202, quest = 78285, level = 25}) -- Coalesced Dreamstone
 
-map.nodes[41766650] = PT.Leatherworking({id = 210208, quest = 78298}) -- Tuft of Dreamsaber Fur
+map.nodes[41766650] = PT.Leatherworking({id = 210208, quest = 78298, level = 25}) -- Tuft of Dreamsaber Fur
 
 map.nodes[37467101] = PT.Leatherworking({
     id = 210211,
     quest = 78299,
+    level = 25,
     note = L['molted_faerie_dragon_scales_note']
 }) -- Molted Faerie Dragon Scales
 
 map.nodes[33992968] = PT.Leatherworking({
     id = 210215,
     quest = 78305,
+    level = 25,
     note = L['dreamtalon_claw_note']
 }) -- Dreamtalon Claw
 

--- a/plugins/10_Dragonflight/zones/ohnahran_plains.lua
+++ b/plugins/10_Dragonflight/zones/ohnahran_plains.lua
@@ -1022,48 +1022,56 @@ map.nodes[36165256] = PetBattle({
 map.nodes[25203540] = PT.Jewelcrafting({
     id = 198670,
     quest = 70282,
+    level = 25,
     note = L['pt_jewel_lofty_malygite_note']
 }) -- Lofty Malygite
 
 map.nodes[35344012] = PT.Tailoring({
     id = 198692,
     quest = 70295,
+    level = 25,
     note = L['pt_tailor_noteworthy_scrap_of_carpet_note']
 }) -- Noteworthy Scrap of Carpet
 
 map.nodes[50906650] = PT.Blacksmithing({
     id = 201009,
     quest = 70353,
+    level = 25,
     note = L['pt_smith_falconer_gauntlet_drawings_note']
 }) -- Falconer Gauntlet Drawings
 
 map.nodes[61406760] = PT.Enchanting({
     id = 198689,
     quest = 70291,
+    level = 25,
     note = L['pt_ench_stormbound_horn_note']
 }) -- Stormbound Horn
 
 map.nodes[61801300] = PT.Jewelcrafting({
     id = 198660,
     quest = 70263,
+    level = 25,
     note = L['pt_jewel_fragmented_key_note']
 }) -- Fragmented Key
 
 map.nodes[66105290] = PT.Tailoring({
     id = 201020,
     quest = 70303,
+    level = 25,
     note = L['pt_tailor_silky_surprise_note']
 }) -- Silky Surprise
 
 map.nodes[79238374] = PT.Alchemy({
     id = 198710,
     quest = 70305,
+    level = 25,
     note = L['pt_alch_canteen_of_suspicious_water_note']
 }) -- Canteen Of Suspicious Water
 
 map.nodes[81103790] = PT.Blacksmithing({
     id = 201004,
     quest = 70313,
+    level = 25,
     note = L['pt_smith_ancient_spear_shards_note'],
     pois = {POI({79403650})}
 }) -- Ancient Spear Shards
@@ -1071,12 +1079,14 @@ map.nodes[81103790] = PT.Blacksmithing({
 map.nodes[85702520] = PT.Inscription({
     id = 198703,
     quest = 70307,
+    level = 25,
     note = L['pt_script_sign_language_reference_sheet_note']
 }) -- Sign Language Reference Sheet
 
 map.nodes[86405370] = PT.Leatherworking({
     id = 198696,
     quest = 70300,
+    level = 25,
     note = L['pt_leath_wind_blessed_hide_note']
 }) -- Wind-Blessed Hide
 
@@ -1085,6 +1095,7 @@ map.nodes[86405370] = PT.Leatherworking({
 map.nodes[82455067] = PM.Leatherworking({
     id = 194842,
     quest = 70256,
+    level = 25,
     note = L['pm_leath_erden'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1095,6 +1106,7 @@ map.nodes[82455067] = PM.Leatherworking({
 map.nodes[58375000] = PM.Herbalism({
     id = 194839,
     quest = 70253,
+    level = 25,
     note = L['pm_herb_hua_greenpaw'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1105,6 +1117,7 @@ map.nodes[58375000] = PM.Herbalism({
 map.nodes[62441868] = PM.Enchanting({
     id = 194837,
     quest = 70251,
+    level = 25,
     note = L['pm_ench_shalasar_glimmerdusk'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle

--- a/plugins/10_Dragonflight/zones/thaldraszus.lua
+++ b/plugins/10_Dragonflight/zones/thaldraszus.lua
@@ -939,30 +939,35 @@ map.nodes[55974053] = PetBattle({
 map.nodes[52208050] = PT.Blacksmithing({
     id = 201006,
     quest = 70311,
+    level = 25,
     note = L['pt_smith_draconic_flux_note']
 }) -- Draconic Flux
 
 map.nodes[55203050] = PT.Alchemy({
     id = 203471,
     quest = 70278,
+    level = 25,
     note = L['pt_alch_tasty_candy_note']
 }) -- Tasty Candy
 
 map.nodes[56104090] = PT.Inscription({
     id = 201015,
     quest = 70287,
+    level = 25,
     note = L['pt_script_counterfeit_darkmoon_deck_note']
 }) -- Counterfeit Darkmoon Deck
 
 map.nodes[56304120] = PT.Inscription({
     id = 198659,
     quest = 70264,
+    level = 25,
     note = L['pt_script_forgetful_apprentices_tome_note']
 }) -- Forgetful Apprentice's Tome
 
 map.nodes[47104007] = PT.Inscription({
     id = 198659,
     quest = 70248,
+    level = 25,
     note = L['pt_script_forgetful_apprentices_tome_algethera_note'],
     pois = {POI({49844031})}
 }) -- Forgetful Apprentice's Tome
@@ -970,48 +975,56 @@ map.nodes[47104007] = PT.Inscription({
 map.nodes[56803050] = PT.Leatherworking({
     id = 198690,
     quest = 70294,
+    level = 25,
     note = L['pt_leath_decayed_scales_note']
 }) -- Decayed Scales
 
 map.nodes[56914372] = PT.Jewelcrafting({
     id = 198656,
     quest = 70261,
+    level = 25,
     note = L['pt_jewel_painters_pretty_jewel_note']
 }) -- Painter's Pretty Jewel
 
 map.nodes[58604580] = PT.Tailoring({
     id = 201019,
     quest = 70372,
+    level = 25,
     note = L['pt_tailor_ancient_dragonweave_bolt_note']
 }) -- Ancient Dragonweave Bolt
 
 map.nodes[59503840] = PT.Alchemy({
     id = 198697,
     quest = 70301,
+    level = 25,
     note = L['pt_alch_contraband_concoction_note']
 }) -- Contraband Concoction
 
 map.nodes[59806520] = PT.Jewelcrafting({
     id = 198682,
     quest = 70285,
+    level = 25,
     note = L['pt_jewel_alexstraszite_cluster_note']
 }) -- Alexstraszite Cluster
 
 map.nodes[59897033] = PT.Enchanting({
     id = 198800,
     quest = 70342,
+    level = 25,
     note = L['pt_ench_fractured_titanic_sphere_note']
 }) -- Fractured Titanic Sphere
 
 map.nodes[60407970] = PT.Tailoring({
     id = 198684,
     quest = 70288,
+    level = 25,
     note = L['pt_tailor_miniature_bronze_dragonflight_banner_note']
 }) -- Miniature Bronze Dragonflight Banner
 
 val.nodes[13206368] = PT.Inscription({
     id = 198669,
     quest = 70281,
+    level = 25,
     parent = map.id,
     note = L['pt_script_how_to_train_your_whelpling_note']
 }) -- How to Train Your Whelpling
@@ -1021,6 +1034,7 @@ val.nodes[13206368] = PT.Inscription({
 map.nodes[61437687] = PM.Mining({
     id = 194843,
     quest = 70258,
+    level = 25,
     note = L['pm_mining_bridgette_holdug'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1031,6 +1045,7 @@ map.nodes[61437687] = PM.Mining({
 val.nodes[27894576] = PM.Tailoring({
     id = 194845,
     quest = 70260,
+    level = 25,
     note = L['pm_tailor_elysa_raywinder'],
     parent = map.id,
     rewards = {

--- a/plugins/10_Dragonflight/zones/waking_shores.lua
+++ b/plugins/10_Dragonflight/zones/waking_shores.lua
@@ -1073,66 +1073,77 @@ map.nodes[69014673] = PetBattle({
 map.nodes[22258763] = PT.Blacksmithing({
     id = 201007,
     quest = 70246,
+    level = 25,
     note = L['pt_smith_ancient_monument_note']
 }) -- Ancient Monument
 
 map.nodes[24906970] = PT.Tailoring({
     id = 198702,
     quest = 70304,
+    level = 25,
     note = L['pt_tailor_itinerant_singed_fabric_note']
 }) -- Itinerant Singed Fabric
 
 map.nodes[25107411] = PT.Alchemy({
     id = 198685,
     quest = 70289,
+    level = 25,
     note = L['pt_alch_well_insulated_mug_note']
 }) -- Well-Insulated Mug
 
 map.nodes[33906370] = PT.Jewelcrafting({
     id = 201017,
     quest = 70273,
+    level = 25,
     note = L['pt_jewel_igneous_gem_note']
 }) -- Igneous Gem
 
 map.nodes[34506710] = PT.Blacksmithing({
     id = 201010,
     quest = 70310,
+    level = 25,
     note = L['pt_smith_qalashi_weapon_diagram_note']
 }) -- Qalashi Weapon Diagram
 
 map.nodes[35506430] = PT.Blacksmithing({
     id = 201008,
     quest = 70296,
+    level = 25,
     note = L['pt_smith_molten_ingot_note']
 }) -- Molten Ingot
 
 map.nodes[39008600] = PT.Leatherworking({
     id = 198711,
     quest = 70308,
+    level = 25,
     note = L['pt_leath_poachers_pack_note']
 }) -- Poacher's Pack
 
 map.nodes[49097754] = PT.Engineering({
     id = 198789,
     quest = 70275,
+    level = 25,
     note = L['pt_engi_intact_coil_capacitor_note']
 }) -- Intact Coil Capacitor
 
 map.nodes[50404510] = PT.Jewelcrafting({
     id = 198687,
     quest = 70292,
+    level = 25,
     note = L['pt_jewel_closely_guarded_shiny_note']
 }) -- Closely Guarded Shiny
 
 map.nodes[55008100] = PT.Alchemy({
     id = 198663,
     quest = 70274,
+    level = 25,
     note = L['pt_alch_frostforged_potion_note']
 }) -- Frostforged Potion
 
 map.nodes[56004490] = PT.Engineering({
     id = 201014,
     quest = 70270,
+    level = 25,
     note = L['pt_engi_boomthyr_rocket_note'],
     pois = {POI({55904529, 58134453, 57994435, 57834457})}
 }) -- Boomthyr Rocket
@@ -1140,48 +1151,56 @@ map.nodes[56004490] = PT.Engineering({
 map.nodes[56401950] = PT.Blacksmithing({
     id = 198791,
     quest = 70230,
+    level = 25,
     note = L['pt_smith_glimmer_of_blacksmithing_wisdom_note']
 }) -- Glimmer of Blacksmithing Wisdom
 
 map.nodes[57505850] = PT.Enchanting({
     id = 201012,
     quest = 70272,
+    level = 25,
     note = L['pt_ench_enchanted_debris_note']
 }) -- Enchanted Debris
 
 map.nodes[57508360] = PT.Enchanting({
     id = 198798,
     quest = 70320,
+    level = 25,
     note = L['pt_ench_flashfrozen_scroll_note']
 }) -- Flashfrozen Scroll
 
 map.nodes[64302540] = PT.Leatherworking({
     id = 198667,
     quest = 70280,
+    level = 25,
     note = L['pt_leath_spare_djaradin_tools_note']
 }) -- Spare Djaradin Tools
 
 map.nodes[65502570] = PT.Blacksmithing({
     id = 201005,
     quest = 70312,
+    level = 25,
     note = L['pt_smith_curious_ingots_note']
 }) -- Curious Ingots
 
 map.nodes[67875796] = PT.Inscription({
     id = 198704,
     quest = 70306,
+    level = 25,
     note = L['pt_script_pulsing_earth_rune_note']
 }) -- Pulsing Earth Rune
 
 map.nodes[68002680] = PT.Enchanting({
     id = 198675,
     quest = 70283,
+    level = 25,
     note = L['pt_ench_lava_infused_seed_note']
 }) -- Lava-Infused Seed
 
 map.nodes[74703790] = PT.Tailoring({
     id = 198699,
     quest = 70302,
+    level = 25,
     note = L['pt_tailor_mysterious_banner_note']
 }) -- Mysterious Banner
 
@@ -1190,6 +1209,7 @@ map.nodes[74703790] = PT.Tailoring({
 map.nodes[43276663] = PM.Blacksmithing({
     id = 194836,
     quest = 70250,
+    level = 25,
     note = L['pm_smith_grekka_anvilsmash'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1200,6 +1220,7 @@ map.nodes[43276663] = PM.Blacksmithing({
 map.nodes[60827590] = PM.Alchemy({
     id = 194829,
     quest = 70247,
+    level = 25,
     note = L['pm_alch_grigori_vialtry'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle
@@ -1210,6 +1231,7 @@ map.nodes[60827590] = PM.Alchemy({
 map.nodes[73286972] = PM.Skinning({
     id = 194844,
     quest = 70259,
+    level = 25,
     note = L['pm_skin_zenzi'],
     rewards = {
         Item({item = 190456, count = '25'}), -- Artisan's Mettle

--- a/plugins/10_Dragonflight/zones/zaralek_cavern.lua
+++ b/plugins/10_Dragonflight/zones/zaralek_cavern.lua
@@ -858,21 +858,9 @@ map.nodes[54472026] = PT.Inscription({
     pois = {POI({52781885})}
 }) -- Ancient Research
 
-map.nodes[34504542] = PT.Jewelcrafting({
-    id = 205216,
-    quest = 75653,
-    level = 25
-}) -- Gently Jostled Jewels
-map.nodes[40378070] = PT.Jewelcrafting({
-    id = 205214,
-    quest = 75652,
-    level = 25
-}) -- Snubbed Snail Shells
-map.nodes[54413247] = PT.Jewelcrafting({
-    id = 205219,
-    quest = 75654,
-    level = 25
-}) -- Broken Barter Boulder
+map.nodes[34504542] = PT.Jewelcrafting({id = 205216, quest = 75653, level = 25}) -- Gently Jostled Jewels
+map.nodes[40378070] = PT.Jewelcrafting({id = 205214, quest = 75652, level = 25}) -- Snubbed Snail Shells
+map.nodes[54413247] = PT.Jewelcrafting({id = 205219, quest = 75654, level = 25}) -- Broken Barter Boulder
 
 map.nodes[44521565] = PT.Tailoring({id = 206030, quest = 76116, level = 25}) -- Exquisitely Embroidered Banner
 map.nodes[47214855] = PT.Tailoring({id = 206019, quest = 76102, level = 25}) -- Abandoned Reserve Chute
@@ -907,37 +895,16 @@ map.nodes[57657393] = PT.Engineering({
     note = L['bolts_and_brass_note']
 }) -- Bolts and Brass (Handful of Khaz'gorite Bolts)
 
-map.nodes[27514286] = PT.Blacksmithing({
-    id = 205988,
-    quest = 76080,
-    level = 25
-}) -- Zaqali Elder Spear
-map.nodes[48312201] = PT.Blacksmithing({
-    id = 205987,
-    quest = 76079,
-    level = 25
-}) -- Brimstone Rescue Ring
-map.nodes[57155464] = PT.Blacksmithing({
-    id = 205986,
-    quest = 76078,
-    level = 25
-}) -- Well-Worn Kiln
+map.nodes[27514286] = PT.Blacksmithing({id = 205988, quest = 76080, level = 25}) -- Zaqali Elder Spear
+map.nodes[48312201] = PT.Blacksmithing({id = 205987, quest = 76079, level = 25}) -- Brimstone Rescue Ring
+map.nodes[57155464] = PT.Blacksmithing({id = 205986, quest = 76078, level = 25}) -- Well-Worn Kiln
 
-map.nodes[41164881] = PT.Leatherworking({
-    id = 204986,
-    quest = 75495,
-    level = 25
-}) -- Flame-Infused Scale Oil
-map.nodes[45252112] = PT.Leatherworking({
-    id = 204987,
-    quest = 75496,
-    level = 25
-}) -- Lava-Forged Leatherworker's "Knife"
-map.nodes[49565480] = PT.Leatherworking({
-    id = 204988,
-    quest = 75502,
-    level = 25
-}) -- Sulfur-Soaked Skins
+map.nodes[41164881] =
+    PT.Leatherworking({id = 204986, quest = 75495, level = 25}) -- Flame-Infused Scale Oil
+map.nodes[45252112] =
+    PT.Leatherworking({id = 204987, quest = 75496, level = 25}) -- Lava-Forged Leatherworker's "Knife"
+map.nodes[49565480] =
+    PT.Leatherworking({id = 204988, quest = 75502, level = 25}) -- Sulfur-Soaked Skins
 
 -------------------------------------------------------------------------------
 -------------------------------- DRAGON GLYPHS --------------------------------

--- a/plugins/10_Dragonflight/zones/zaralek_cavern.lua
+++ b/plugins/10_Dragonflight/zones/zaralek_cavern.lua
@@ -844,60 +844,64 @@ map.nodes[45698150] = PetBattle({
 ----------------------------- PROFESSION TREASURES ----------------------------
 -------------------------------------------------------------------------------
 
-map.nodes[40485918] = PT.Alchemy({id = 205213, quest = 75651}) -- Suspicious Mold
-map.nodes[52631830] = PT.Alchemy({id = 205211, quest = 75646}) -- Nutrient Diluted Protofluid
-map.nodes[62154115] = PT.Alchemy({id = 205212, quest = 75649}) -- Marrow-Ripened Slime
+map.nodes[40485918] = PT.Alchemy({id = 205213, quest = 75651, level = 25}) -- Suspicious Mold
+map.nodes[52631830] = PT.Alchemy({id = 205211, quest = 75646, level = 25}) -- Nutrient Diluted Protofluid
+map.nodes[62154115] = PT.Alchemy({id = 205212, quest = 75649, level = 25}) -- Marrow-Ripened Slime
 
-map.nodes[36674615] = PT.Inscription({id = 206031, quest = 76117}) -- Intricate Zaqali Runes
-map.nodes[53007440] = PT.Inscription({id = 206034, quest = 76120}) -- Hissing Rune Draft
+map.nodes[36674615] = PT.Inscription({id = 206031, quest = 76117, level = 25}) -- Intricate Zaqali Runes
+map.nodes[53007440] = PT.Inscription({id = 206034, quest = 76120, level = 25}) -- Hissing Rune Draft
 map.nodes[54472026] = PT.Inscription({
     id = 206035,
     quest = 76121,
+    level = 25,
     location = L['in_cave'],
     pois = {POI({52781885})}
 }) -- Ancient Research
 
-map.nodes[34504542] = PT.Jewelcrafting({id = 205216, quest = 75653}) -- Gently Jostled Jewels
-map.nodes[40378070] = PT.Jewelcrafting({id = 205214, quest = 75652}) -- Snubbed Snail Shells
-map.nodes[54413247] = PT.Jewelcrafting({id = 205219, quest = 75654}) -- Broken Barter Boulder
+map.nodes[34504542] = PT.Jewelcrafting({id = 205216, quest = 75653, level = 25}) -- Gently Jostled Jewels
+map.nodes[40378070] = PT.Jewelcrafting({id = 205214, quest = 75652, level = 25}) -- Snubbed Snail Shells
+map.nodes[54413247] = PT.Jewelcrafting({id = 205219, quest = 75654, level = 25}) -- Broken Barter Boulder
 
-map.nodes[44521565] = PT.Tailoring({id = 206030, quest = 76116}) -- Exquisitely Embroidered Banner
-map.nodes[47214855] = PT.Tailoring({id = 206019, quest = 76102}) -- Abandoned Reserve Chute
-map.nodes[59117314] = PT.Tailoring({id = 206025, quest = 76110}) -- Used Medical Wrap Kit
+map.nodes[44521565] = PT.Tailoring({id = 206030, quest = 76116, level = 25}) -- Exquisitely Embroidered Banner
+map.nodes[47214855] = PT.Tailoring({id = 206019, quest = 76102, level = 25}) -- Abandoned Reserve Chute
+map.nodes[59117314] = PT.Tailoring({id = 206025, quest = 76110, level = 25}) -- Used Medical Wrap Kit
 
-map.nodes[36666933] = PT.Enchanting({id = 205001, quest = 75510}) -- Resonating Arcane Crystal
-map.nodes[48251702] = PT.Enchanting({id = 204990, quest = 75508}) -- Lava-Drenched Shadow Crystal
-map.nodes[62395380] = PT.Enchanting({id = 204999, quest = 75509}) -- Shimmering Aqueous Orb
+map.nodes[36666933] = PT.Enchanting({id = 205001, quest = 75510, level = 25}) -- Resonating Arcane Crystal
+map.nodes[48251702] = PT.Enchanting({id = 204990, quest = 75508, level = 25}) -- Lava-Drenched Shadow Crystal
+map.nodes[62395380] = PT.Enchanting({id = 204999, quest = 75509, level = 25}) -- Shimmering Aqueous Orb
 
-map.nodes[50504790] = PT.Engineering({id = 204471, quest = 75184}) -- Defective Survival Pack
+map.nodes[50504790] = PT.Engineering({id = 204471, quest = 75184, level = 25}) -- Defective Survival Pack
 map.nodes[37825884] = PT.Engineering({
     id = 204475,
     quest = 75186,
+    level = 25,
     note = L['busted_wyrmhole_generator_note']
 }) -- Busted Wyrmhole Generator
 map.nodes[48101659] = PT.Engineering({
     id = 204855,
     quest = 75433,
+    level = 25,
     location = L['in_small_cave'],
     note = L['molten_scoutbot_note']
 }) -- Molten Scoutbot (Overclocked Determination Core)
-map.nodes[48162790] = PT.Engineering({id = 204470, quest = 75183}) -- Haphazardly Discarded Bombs
-map.nodes[48484868] = PT.Engineering({id = 204469, quest = 75180}) -- Misplace Aberrus Outflow Blueprints
-map.nodes[49437901] = PT.Engineering({id = 204853, quest = 75431}) -- Discarded Dracothyst Drill
-map.nodes[49875919] = PT.Engineering({id = 204480, quest = 75188}) -- Inconspicuous Data Miner
+map.nodes[48162790] = PT.Engineering({id = 204470, quest = 75183, level = 25}) -- Haphazardly Discarded Bombs
+map.nodes[48484868] = PT.Engineering({id = 204469, quest = 75180, level = 25}) -- Misplace Aberrus Outflow Blueprints
+map.nodes[49437901] = PT.Engineering({id = 204853, quest = 75431, level = 25}) -- Discarded Dracothyst Drill
+map.nodes[49875919] = PT.Engineering({id = 204480, quest = 75188, level = 25}) -- Inconspicuous Data Miner
 map.nodes[57657393] = PT.Engineering({
     id = 204850,
     quest = 75430,
+    level = 25,
     note = L['bolts_and_brass_note']
 }) -- Bolts and Brass (Handful of Khaz'gorite Bolts)
 
-map.nodes[27514286] = PT.Blacksmithing({id = 205988, quest = 76080}) -- Zaqali Elder Spear
-map.nodes[48312201] = PT.Blacksmithing({id = 205987, quest = 76079}) -- Brimstone Rescue Ring
-map.nodes[57155464] = PT.Blacksmithing({id = 205986, quest = 76078}) -- Well-Worn Kiln
+map.nodes[27514286] = PT.Blacksmithing({id = 205988, quest = 76080, level = 25}) -- Zaqali Elder Spear
+map.nodes[48312201] = PT.Blacksmithing({id = 205987, quest = 76079, level = 25}) -- Brimstone Rescue Ring
+map.nodes[57155464] = PT.Blacksmithing({id = 205986, quest = 76078, level = 25}) -- Well-Worn Kiln
 
-map.nodes[41164881] = PT.Leatherworking({id = 204986, quest = 75495}) -- Flame-Infused Scale Oil
-map.nodes[45252112] = PT.Leatherworking({id = 204987, quest = 75496}) -- Lava-Forged Leatherworker's "Knife"
-map.nodes[49565480] = PT.Leatherworking({id = 204988, quest = 75502}) -- Sulfur-Soaked Skins
+map.nodes[41164881] = PT.Leatherworking({id = 204986, quest = 75495, level = 25}) -- Flame-Infused Scale Oil
+map.nodes[45252112] = PT.Leatherworking({id = 204987, quest = 75496, level = 25}) -- Lava-Forged Leatherworker's "Knife"
+map.nodes[49565480] = PT.Leatherworking({id = 204988, quest = 75502, level = 25}) -- Sulfur-Soaked Skins
 
 -------------------------------------------------------------------------------
 -------------------------------- DRAGON GLYPHS --------------------------------

--- a/plugins/10_Dragonflight/zones/zaralek_cavern.lua
+++ b/plugins/10_Dragonflight/zones/zaralek_cavern.lua
@@ -858,9 +858,21 @@ map.nodes[54472026] = PT.Inscription({
     pois = {POI({52781885})}
 }) -- Ancient Research
 
-map.nodes[34504542] = PT.Jewelcrafting({id = 205216, quest = 75653, level = 25}) -- Gently Jostled Jewels
-map.nodes[40378070] = PT.Jewelcrafting({id = 205214, quest = 75652, level = 25}) -- Snubbed Snail Shells
-map.nodes[54413247] = PT.Jewelcrafting({id = 205219, quest = 75654, level = 25}) -- Broken Barter Boulder
+map.nodes[34504542] = PT.Jewelcrafting({
+    id = 205216,
+    quest = 75653,
+    level = 25
+}) -- Gently Jostled Jewels
+map.nodes[40378070] = PT.Jewelcrafting({
+    id = 205214,
+    quest = 75652,
+    level = 25
+}) -- Snubbed Snail Shells
+map.nodes[54413247] = PT.Jewelcrafting({
+    id = 205219,
+    quest = 75654,
+    level = 25
+}) -- Broken Barter Boulder
 
 map.nodes[44521565] = PT.Tailoring({id = 206030, quest = 76116, level = 25}) -- Exquisitely Embroidered Banner
 map.nodes[47214855] = PT.Tailoring({id = 206019, quest = 76102, level = 25}) -- Abandoned Reserve Chute
@@ -895,13 +907,37 @@ map.nodes[57657393] = PT.Engineering({
     note = L['bolts_and_brass_note']
 }) -- Bolts and Brass (Handful of Khaz'gorite Bolts)
 
-map.nodes[27514286] = PT.Blacksmithing({id = 205988, quest = 76080, level = 25}) -- Zaqali Elder Spear
-map.nodes[48312201] = PT.Blacksmithing({id = 205987, quest = 76079, level = 25}) -- Brimstone Rescue Ring
-map.nodes[57155464] = PT.Blacksmithing({id = 205986, quest = 76078, level = 25}) -- Well-Worn Kiln
+map.nodes[27514286] = PT.Blacksmithing({
+    id = 205988,
+    quest = 76080,
+    level = 25
+}) -- Zaqali Elder Spear
+map.nodes[48312201] = PT.Blacksmithing({
+    id = 205987,
+    quest = 76079,
+    level = 25
+}) -- Brimstone Rescue Ring
+map.nodes[57155464] = PT.Blacksmithing({
+    id = 205986,
+    quest = 76078,
+    level = 25
+}) -- Well-Worn Kiln
 
-map.nodes[41164881] = PT.Leatherworking({id = 204986, quest = 75495, level = 25}) -- Flame-Infused Scale Oil
-map.nodes[45252112] = PT.Leatherworking({id = 204987, quest = 75496, level = 25}) -- Lava-Forged Leatherworker's "Knife"
-map.nodes[49565480] = PT.Leatherworking({id = 204988, quest = 75502, level = 25}) -- Sulfur-Soaked Skins
+map.nodes[41164881] = PT.Leatherworking({
+    id = 204986,
+    quest = 75495,
+    level = 25
+}) -- Flame-Infused Scale Oil
+map.nodes[45252112] = PT.Leatherworking({
+    id = 204987,
+    quest = 75496,
+    level = 25
+}) -- Lava-Forged Leatherworker's "Knife"
+map.nodes[49565480] = PT.Leatherworking({
+    id = 204988,
+    quest = 75502,
+    level = 25
+}) -- Sulfur-Soaked Skins
 
 -------------------------------------------------------------------------------
 -------------------------------- DRAGON GLYPHS --------------------------------

--- a/plugins/11_TheWarWithin/common.lua
+++ b/plugins/11_TheWarWithin/common.lua
@@ -30,11 +30,6 @@ ns.groups.DISTURBED_EARTH = Group('disturbed_earth', 132386, {
     type = ns.group_types.EXPANSION
 })
 
-ns.groups.PROFESSION_TREASURES = Group('profession_treasures', 4620676, {
-    defaults = ns.GROUP_HIDDEN,
-    type = ns.group_types.EXPANSION
-})
-
 ns.groups.RATTS_REVENGE = Group('ratts_revenge', 5370377, {
     defaults = ns.GROUP_HIDDEN,
     type = ns.group_types.EXPANSION
@@ -286,57 +281,6 @@ local SkyridingGlyph = Class('SkyridingGlyph', Collectible, {
 })
 
 ns.node.SkyridingGlyph = SkyridingGlyph
-
--------------------------------------------------------------------------------
------------------------------ PROFESSION TREASURES ----------------------------
--------------------------------------------------------------------------------
-
-local ProfessionMaster = Class('ProfessionMaster', ns.node.NPC, {
-    scale = 0.9,
-    group = ns.groups.PROFESSION_TREASURES
-})
-
-function ProfessionMaster:IsEnabled()
-    if not ns.PlayerHasProfession(self.skillID) then return false end
-    return ns.node.NPC.IsEnabled(self)
-end
-
-local ProfessionTreasure = Class('ProfessionTreasure', ns.node.Item, {
-    scale = 0.9,
-    group = ns.groups.PROFESSION_TREASURES
-})
-
-function ProfessionTreasure:IsEnabled()
-    if not ns.PlayerHasProfession(self.skillID) then return false end
-    return ns.node.Item.IsEnabled(self)
-end
-
-ns.node.ProfessionMasters = {}
-ns.node.ProfessionTreasures = {}
-
-local PM = ns.node.ProfessionMasters
-local PT = ns.node.ProfessionTreasures
-
-for _, profession in pairs(ns.professions) do
-    if profession.variantID ~= nil then
-        local name = profession.name
-        local icon = profession.icon
-        local skillID = profession.skillID
-        local variantID = profession.variantID[11]
-
-        PM[name] = Class(name .. 'Master', ProfessionMaster, {
-            icon = icon,
-            skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 1)
-        })
-
-        PT[name] = Class(name .. 'Treasure', ProfessionTreasure, {
-            icon = icon,
-            skillID = skillID,
-            requires = ns.requirement.Profession(skillID, variantID, 1)
-        })
-    end
-end
 
 -------------------------------------------------------------------------------
 -------------------------------- DISTURBED DIRT -------------------------------


### PR DESCRIPTION
Profession treasures now span 3 expansions (Dragonflight, The War Within, and Midnight) so its time to move them to core.

- The default level for the profession requirement is `1` but can be overwritten (example: `level = 25`)
- `variantID` is fetched via `ns.expansion` and there is now a "reverse lookup" to find professions via `skillID`