### PR TITLE
feat(tests): add header comment format lint check

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -176,4 +176,8 @@ files["tests/test_locales.lua"] = {
         'format',
     }
 }
+
+files["tests/test_headers.lua"] = {
+    globals = {'TestHeaders'}
+}
 -- LuaFormatter on

--- a/build.sh
+++ b/build.sh
@@ -82,6 +82,7 @@ function run-linter() {
 function run-tests() {
     (cd tests && lua test_class.lua ${VERBOSE:-})
     (cd tests && lua test_locales.lua ${VERBOSE:-})
+    (cd tests && lua test_headers.lua ${VERBOSE:-})
 }
 
 function run-formatter() {

--- a/lint_local.ps1
+++ b/lint_local.ps1
@@ -1,0 +1,33 @@
+# Local lint runner for handynotes-plugins
+# Requires Lua and lua-format to be installed
+
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$f = "$env:APPDATA\npm\node_modules\lua-format\src\index.js"
+$lua = (where.exe lua 2>$null) | Select-Object -First 1
+
+if (-not $lua) {
+    Write-Error "Lua not found. Install: winget install DEVCOM.Lua"
+    exit 1
+}
+if (-not (Test-Path $f)) {
+    Write-Error "lua-format not found. Install: npm install -g lua-format"
+    exit 1
+}
+
+Write-Host "=== Luacheck ==="
+luacheck core plugins tests/test_*.lua -q --no-color 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) { Write-Host "luacheck FAILED" -ForegroundColor Red; $failed = $true }
+
+Write-Host "`n=== Lua Format Check ==="
+node $f -c "$root\.lua-format" --check "$root\core" "$root\plugins" "$root\tests" 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) { Write-Host "format FAILED" -ForegroundColor Red; $failed = $true }
+
+Write-Host "`n=== Unit Tests ==="
+Push-Location "$root\tests"
+& $lua test_class.lua 2>&1 | ForEach-Object { Write-Host $_ }
+& $lua test_locales.lua 2>&1 | ForEach-Object { Write-Host $_ }
+& $lua test_headers.lua 2>&1 | ForEach-Object { Write-Host $_ }
+Pop-Location
+
+if ($failed) { Write-Host "`nFAILED" -ForegroundColor Red; exit 1 }
+else { Write-Host "`nALL PASSED" -ForegroundColor Green }

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -1,0 +1,117 @@
+-------------------------------------------------------------------------------
+--------------------------------- LOAD MODULE ---------------------------------
+-------------------------------------------------------------------------------
+local luaunit = require('luaunit')
+local utils = require('utils')
+
+-- Header format constants
+local LINE_LEN = 79
+local BODY_LEN = LINE_LEN - 2  -- 77 chars after "--"
+local SEP = '--' .. string.rep('-', BODY_LEN)
+
+-------------------------------------------------------------------------------
+-------------------------- FUNCTIONS TO VERIFY HEADERS ------------------------
+-------------------------------------------------------------------------------
+
+local function CheckSeparator(line, lineNum, file)
+    -- Must be exactly LINE_LEN chars with 77 dashes after "--"
+    if #line ~= LINE_LEN then
+        error(string.format('%s:%d: separator len=%d, expected %d',
+            file, lineNum, #line, LINE_LEN))
+    end
+    if line ~= SEP then
+        -- Show diff by finding where it differs
+        for i = 1, LINE_LEN do
+            if line:sub(i, i) ~= SEP:sub(i, i) then
+                error(string.format(
+                    '%s:%d: separator mismatch at pos %d', file, lineNum, i))
+            end
+        end
+    end
+end
+
+local function CheckHeaderText(line, lineNum, file)
+    if #line ~= LINE_LEN then
+        error(string.format('%s:%d: header len=%d, expected %d',
+            file, lineNum, #line, LINE_LEN))
+    end
+
+    -- Extract text, left dash count, right dash count
+    local _, _, text = line:find('^--%-+ (.+) %-+$')
+    if not text then
+        error(string.format('%s:%d: malformed header: %s', file, lineNum, line))
+    end
+
+    local textLen = #text + 2  -- spaces around text
+    local dashCount = BODY_LEN - textLen
+
+    if dashCount <= 0 then
+        error(string.format('%s:%d: header text too long (%d chars)',
+            file, lineNum, #text))
+    end
+
+    -- Count actual dashes after "--"
+    local leftDashes = 0
+    for i = 3, #line do
+        if line:sub(i, i) == '-' then leftDashes = leftDashes + 1
+        else break end
+    end
+
+    local rightDashes = 0
+    for i = #line, 3, -1 do
+        if line:sub(i, i) == '-' then rightDashes = rightDashes + 1
+        else break end
+    end
+
+    -- Verify dash counts add up
+    if leftDashes + textLen + rightDashes ~= BODY_LEN then
+        error(string.format('%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d',
+            file, lineNum, leftDashes, rightDashes, textLen,
+            leftDashes + textLen + rightDashes, BODY_LEN))
+    end
+
+    -- Visual balance check: "--" + leftDashes should be close to rightDashes
+    -- Goal: 2 + leftDashes = rightDashes (balanced), or diff=±1 for odd
+    -- Right gets fewer on odd (so 2 + leftDashes > rightDashes)
+    local visualDiff = (2 + leftDashes) - rightDashes
+    if visualDiff < 0 or visualDiff > 1 then
+        error(string.format(
+            '%s:%d: visual imbalance %s L=%d R=%d (visL=%d visR=%d diff=%d, expected 0 or 1)',
+            file, lineNum, text, leftDashes, rightDashes,
+            2 + leftDashes, rightDashes, visualDiff))
+    end
+end
+
+-------------------------------------------------------------------------------
+----------------------------- HEADER PATTERN TEST -----------------------------
+-------------------------------------------------------------------------------
+
+TestHeaders = {}
+
+function TestHeaders:testAllHeaders()
+    local errors = {}
+    for file in utils.AllLuaFiles() do
+        local filepath = file:match('^%.%./(.+)$') or file
+        for lineNum, line in utils.FileLines(file) do
+            -- Separator: -- followed by at least 10 dashes
+            if line:match('^--%-{10,}$') then
+                local ok, err = pcall(CheckSeparator, line, lineNum, file)
+                if not ok then errors[#errors + 1] = err end
+            -- Header text: --dashes, space, text, space, dashes
+            elseif #line >= 20 and line:match('^--%-{10,} .+ %-{10,}$') then
+                local ok, err = pcall(CheckHeaderText, line, lineNum, file)
+                if not ok then errors[#errors + 1] = err end
+            end
+        end
+    end
+
+    if #errors > 0 then
+        local msg = table.concat(errors, '\n')
+        error(msg, 0)
+    end
+end
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+os.exit(luaunit.LuaUnit.run())

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -6,7 +6,7 @@ local utils = require('utils')
 
 -- Header format constants
 local LINE_LEN = 79
-local BODY_LEN = LINE_LEN - 2  -- 77 chars after "--"
+local BODY_LEN = LINE_LEN - 2 -- 77 chars after "--"
 local SEP = '--' .. string.rep('-', BODY_LEN)
 
 -------------------------------------------------------------------------------
@@ -16,15 +16,15 @@ local SEP = '--' .. string.rep('-', BODY_LEN)
 local function CheckSeparator(line, lineNum, file)
     -- Must be exactly LINE_LEN chars with 77 dashes after "--"
     if #line ~= LINE_LEN then
-        error(string.format('%s:%d: separator len=%d, expected %d',
-            file, lineNum, #line, LINE_LEN))
+        error(string.format('%s:%d: separator len=%d, expected %d', file,
+            lineNum, #line, LINE_LEN))
     end
     if line ~= SEP then
         -- Show diff by finding where it differs
         for i = 1, LINE_LEN do
             if line:sub(i, i) ~= SEP:sub(i, i) then
-                error(string.format(
-                    '%s:%d: separator mismatch at pos %d', file, lineNum, i))
+                error(string.format('%s:%d: separator mismatch at pos %d', file,
+                    lineNum, i))
             end
         end
     end
@@ -32,8 +32,8 @@ end
 
 local function CheckHeaderText(line, lineNum, file)
     if #line ~= LINE_LEN then
-        error(string.format('%s:%d: header len=%d, expected %d',
-            file, lineNum, #line, LINE_LEN))
+        error(string.format('%s:%d: header len=%d, expected %d', file, lineNum,
+            #line, LINE_LEN))
     end
 
     -- Extract text, left dash count, right dash count
@@ -42,31 +42,38 @@ local function CheckHeaderText(line, lineNum, file)
         error(string.format('%s:%d: malformed header: %s', file, lineNum, line))
     end
 
-    local textLen = #text + 2  -- spaces around text
+    local textLen = #text + 2 -- spaces around text
     local dashCount = BODY_LEN - textLen
 
     if dashCount <= 0 then
-        error(string.format('%s:%d: header text too long (%d chars)',
-            file, lineNum, #text))
+        error(string.format('%s:%d: header text too long (%d chars)', file,
+            lineNum, #text))
     end
 
     -- Count actual dashes after "--"
     local leftDashes = 0
     for i = 3, #line do
-        if line:sub(i, i) == '-' then leftDashes = leftDashes + 1
-        else break end
+        if line:sub(i, i) == '-' then
+            leftDashes = leftDashes + 1
+        else
+            break
+        end
     end
 
     local rightDashes = 0
     for i = #line, 3, -1 do
-        if line:sub(i, i) == '-' then rightDashes = rightDashes + 1
-        else break end
+        if line:sub(i, i) == '-' then
+            rightDashes = rightDashes + 1
+        else
+            break
+        end
     end
 
     -- Verify dash counts add up
     if leftDashes + textLen + rightDashes ~= BODY_LEN then
-        error(string.format('%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d',
-            file, lineNum, leftDashes, rightDashes, textLen,
+        error(string.format(
+            '%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d', file,
+            lineNum, leftDashes, rightDashes, textLen,
             leftDashes + textLen + rightDashes, BODY_LEN))
     end
 
@@ -77,8 +84,8 @@ local function CheckHeaderText(line, lineNum, file)
     if visualDiff < 0 or visualDiff > 1 then
         error(string.format(
             '%s:%d: visual imbalance %s L=%d R=%d (visL=%d visR=%d diff=%d, expected 0 or 1)',
-            file, lineNum, text, leftDashes, rightDashes,
-            2 + leftDashes, rightDashes, visualDiff))
+            file, lineNum, text, leftDashes, rightDashes, 2 + leftDashes,
+            rightDashes, visualDiff))
     end
 end
 
@@ -96,7 +103,7 @@ function TestHeaders:testAllHeaders()
             if line:match('^--%-{10,}$') then
                 local ok, err = pcall(CheckSeparator, line, lineNum, file)
                 if not ok then errors[#errors + 1] = err end
-            -- Header text: --dashes, space, text, space, dashes
+                -- Header text: --dashes, space, text, space, dashes
             elseif #line >= 20 and line:match('^--%-{10,} .+ %-{10,}$') then
                 local ok, err = pcall(CheckHeaderText, line, lineNum, file)
                 if not ok then errors[#errors + 1] = err end

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -97,8 +97,12 @@ TestHeaders = {}
 
 function TestHeaders:testAllHeaders()
     local errors = {}
+    local fileCount = 0
+    local lineCount = 0
     for file in utils.AllLuaFiles() do
+        fileCount = fileCount + 1
         for lineNum, line in utils.FileLines(file) do
+            lineCount = lineCount + 1
             -- Separator: -- followed by at least 10 dashes
             if line:match('^--%-{10,}$') then
                 local ok, err = pcall(CheckSeparator, line, lineNum, file)
@@ -111,6 +115,9 @@ function TestHeaders:testAllHeaders()
         end
     end
 
+    if fileCount == 0 then
+        error('no files scanned - AllLuaFiles returned nothing', 0)
+    end
     if #errors > 0 then
         local msg = table.concat(errors, '\n')
         error(msg, 0)

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -14,17 +14,15 @@ local SEP = '--' .. string.rep('-', BODY_LEN)
 -------------------------------------------------------------------------------
 
 local function CheckSeparator(line, lineNum, file)
-    -- Must be exactly LINE_LEN chars with 77 dashes after "--"
     if #line ~= LINE_LEN then
         error(string.format('%s:%d: separator len=%d, expected %d', file,
             lineNum, #line, LINE_LEN))
     end
     if line ~= SEP then
-        -- Show diff by finding where it differs
         for i = 1, LINE_LEN do
             if line:sub(i, i) ~= SEP:sub(i, i) then
-                error(string.format('%s:%d: separator mismatch at pos %d', file,
-                    lineNum, i))
+                error(string.format(
+                    '%s:%d: separator mismatch at pos %d', file, lineNum, i))
             end
         end
     end
@@ -32,14 +30,14 @@ end
 
 local function CheckHeaderText(line, lineNum, file)
     if #line ~= LINE_LEN then
-        error(string.format('%s:%d: header len=%d, expected %d', file, lineNum,
-            #line, LINE_LEN))
+        error(string.format('%s:%d: header len=%d, expected %d', file,
+            lineNum, #line, LINE_LEN))
     end
 
-    -- Extract text, left dash count, right dash count
     local _, _, text = line:find('^--%-+ (.+) %-+$')
     if not text then
-        error(string.format('%s:%d: malformed header: %s', file, lineNum, line))
+        error(string.format('%s:%d: malformed header: %s', file, lineNum,
+            line))
     end
 
     local textLen = #text + 2 -- spaces around text
@@ -69,16 +67,14 @@ local function CheckHeaderText(line, lineNum, file)
         end
     end
 
-    -- Verify dash counts add up
     if leftDashes + textLen + rightDashes ~= BODY_LEN then
         error(string.format(
-            '%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d', file,
-            lineNum, leftDashes, rightDashes, textLen,
+            '%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d',
+            file, lineNum, leftDashes, rightDashes, textLen,
             leftDashes + textLen + rightDashes, BODY_LEN))
     end
 
-    -- Visual balance check: "--" + leftDashes should be close to rightDashes
-    -- Goal: 2 + leftDashes = rightDashes (balanced), or diff=±1 for odd
+    -- Visual balance: 2 + leftDashes should be close to rightDashes
     -- Right gets fewer on odd (so 2 + leftDashes > rightDashes)
     local visualDiff = (2 + leftDashes) - rightDashes
     if visualDiff < 0 or visualDiff > 1 then
@@ -90,6 +86,25 @@ local function CheckHeaderText(line, lineNum, file)
 end
 
 -------------------------------------------------------------------------------
+--------------------------- LINE ITERATOR (sans utils) ------------------------
+-------------------------------------------------------------------------------
+
+local function EachHeaderLine(file)
+    local f = io.open(file, 'r')
+    if not f then return function() end end
+    local i = 0
+    return function()
+        local line = f:read('*l')
+        i = i + 1
+        if line then
+            return i, line
+        else
+            f:close()
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
 ----------------------------- HEADER PATTERN TEST -----------------------------
 -------------------------------------------------------------------------------
 
@@ -97,34 +112,35 @@ TestHeaders = {}
 
 function TestHeaders:testAllHeaders()
     local errors = {}
-    local fileCount = 0
-    local lineCount = 0
-    for file in utils.AllLuaFiles() do
-        fileCount = fileCount + 1
-        for lineNum, line in utils.FileLines(file) do
-            lineCount = lineCount + 1
-            -- Separator: -- followed by at least 10 dashes
-            if line:match('^--%-{10,}$') then
-                local ok, err = pcall(CheckSeparator, line, lineNum, file)
-                if not ok then errors[#errors + 1] = err end
-                -- Header text: --dashes, space, text, space, dashes
-            elseif #line >= 20 and line:match('^--%-{10,} .+ %-{10,}$') then
-                local ok, err = pcall(CheckHeaderText, line, lineNum, file)
-                if not ok then errors[#errors + 1] = err end
+    for file in utils.Code() do
+        local f = io.open(file, 'r')
+        if not f then
+            errors[#errors + 1] = ('cannot open: %s'):format(file)
+        else
+            local lineNum = 0
+            for line in f:lines() do
+                lineNum = lineNum + 1
+                if line:match('^--%-{10,}$') then
+                    local ok, err = pcall(CheckSeparator, line, lineNum,
+                        file)
+                    if not ok then errors[#errors + 1] = err end
+                elseif #line >= 20 and
+                    line:match('^--%-{10,} .+ %-{10,}$') then
+                    local ok, err = pcall(CheckHeaderText, line, lineNum,
+                        file)
+                    if not ok then errors[#errors + 1] = err end
+                end
             end
+            f:close()
         end
     end
 
-    if fileCount == 0 then
-        error('no files scanned - AllLuaFiles returned nothing', 0)
-    end
     if #errors > 0 then
         local msg = table.concat(errors, '\n')
         error(msg, 0)
     end
 end
 
--------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
 os.exit(luaunit.LuaUnit.run())

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -86,8 +86,10 @@ local function CheckHeaderText(line, lineNum, file)
 end
 
 -------------------------------------------------------------------------------
---------------------------- LINE ITERATOR (sans utils) ------------------------
+----------------------------- HEADER PATTERN TEST -----------------------------
 -------------------------------------------------------------------------------
+
+TestHeaders = {}
 
 function TestHeaders:testAllHeaders()
     local errors = {}

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -21,8 +21,8 @@ local function CheckSeparator(line, lineNum, file)
     if line ~= SEP then
         for i = 1, LINE_LEN do
             if line:sub(i, i) ~= SEP:sub(i, i) then
-                error(string.format(
-                    '%s:%d: separator mismatch at pos %d', file, lineNum, i))
+                error(string.format('%s:%d: separator mismatch at pos %d', file,
+                    lineNum, i))
             end
         end
     end
@@ -30,14 +30,13 @@ end
 
 local function CheckHeaderText(line, lineNum, file)
     if #line ~= LINE_LEN then
-        error(string.format('%s:%d: header len=%d, expected %d', file,
-            lineNum, #line, LINE_LEN))
+        error(string.format('%s:%d: header len=%d, expected %d', file, lineNum,
+            #line, LINE_LEN))
     end
 
     local _, _, text = line:find('^--%-+ (.+) %-+$')
     if not text then
-        error(string.format('%s:%d: malformed header: %s', file, lineNum,
-            line))
+        error(string.format('%s:%d: malformed header: %s', file, lineNum, line))
     end
 
     local textLen = #text + 2 -- spaces around text
@@ -69,8 +68,8 @@ local function CheckHeaderText(line, lineNum, file)
 
     if leftDashes + textLen + rightDashes ~= BODY_LEN then
         error(string.format(
-            '%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d',
-            file, lineNum, leftDashes, rightDashes, textLen,
+            '%s:%d: dash mismatch L=%d R=%d text=%d total=%d expected=%d', file,
+            lineNum, leftDashes, rightDashes, textLen,
             leftDashes + textLen + rightDashes, BODY_LEN))
     end
 
@@ -102,13 +101,10 @@ function TestHeaders:testAllHeaders()
             for line in f:lines() do
                 lineNum = lineNum + 1
                 if line:match('^--%-{10,}$') then
-                    local ok, err = pcall(CheckSeparator, line, lineNum,
-                        file)
+                    local ok, err = pcall(CheckSeparator, line, lineNum, file)
                     if not ok then errors[#errors + 1] = err end
-                elseif #line >= 20 and
-                    line:match('^--%-{10,} .+ %-{10,}$') then
-                    local ok, err = pcall(CheckHeaderText, line, lineNum,
-                        file)
+                elseif #line >= 20 and line:match('^--%-{10,} .+ %-{10,}$') then
+                    local ok, err = pcall(CheckHeaderText, line, lineNum, file)
                     if not ok then errors[#errors + 1] = err end
                 end
             end

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -91,7 +91,6 @@ TestHeaders = {}
 function TestHeaders:testAllHeaders()
     local errors = {}
     for file in utils.AllLuaFiles() do
-        local filepath = file:match('^%.%./(.+)$') or file
         for lineNum, line in utils.FileLines(file) do
             -- Separator: -- followed by at least 10 dashes
             if line:match('^--%-{10,}$') then

--- a/tests/test_headers.lua
+++ b/tests/test_headers.lua
@@ -89,27 +89,6 @@ end
 --------------------------- LINE ITERATOR (sans utils) ------------------------
 -------------------------------------------------------------------------------
 
-local function EachHeaderLine(file)
-    local f = io.open(file, 'r')
-    if not f then return function() end end
-    local i = 0
-    return function()
-        local line = f:read('*l')
-        i = i + 1
-        if line then
-            return i, line
-        else
-            f:close()
-        end
-    end
-end
-
--------------------------------------------------------------------------------
------------------------------ HEADER PATTERN TEST -----------------------------
--------------------------------------------------------------------------------
-
-TestHeaders = {}
-
 function TestHeaders:testAllHeaders()
     local errors = {}
     for file in utils.Code() do

--- a/tests/utils.lua
+++ b/tests/utils.lua
@@ -28,4 +28,23 @@ local function Code()
     return io.popen(cmd):lines()
 end
 
-return {FileExists = FileExists, Code = Code, Locales = Locales}
+local function AllLuaFiles()
+    local cmd = 'find ../core ../plugins -name "*.lua"'
+    return io.popen(cmd):lines()
+end
+
+local function FileLines(file)
+    local f = io.open(file, 'r')
+    if not f then return function() end end
+    local lines = {}
+    for line in f:lines() do lines[#lines + 1] = line end
+    f:close()
+    local i = 0
+    return function()
+        i = i + 1
+        if lines[i] then return i, lines[i] end
+    end
+end
+
+return {FileExists = FileExists, Code = Code, Locales = Locales,
+    AllLuaFiles = AllLuaFiles, FileLines = FileLines}


### PR DESCRIPTION
- test_headers.lua: validates all decorative header comments are 79 chars, with proper dash count and visual centering
- utils.lua: add AllLuaFiles() and FileLines() helpers

Visual balance rule: 2 + leftDashes >= rightDashes >= leftDashes
(even: balanced, odd: right gets one fewer dash)